### PR TITLE
Replace RMSX sample with the 1UBQ trajectory example

### DIFF
--- a/1.rmsx.json
+++ b/1.rmsx.json
@@ -1,168 +1,1831 @@
 {
-  "schemaVersion": "flipbook-molstar-viewer/v1",
-  "title": "RMSX Flipbook Example",
-  "slices": [
-    {
-      "index": 1,
-      "id": "slice-1",
-      "label": "Frame 1",
-      "filename": "frame_1.pdb",
-      "rmsxColumn": "rmsx0",
-      "pdb": "ATOM      1 N    ALA A   1      -1.200   0.500   0.000  1.00  0.00           N\nATOM      2 CA   ALA A   1       0.000   0.000   0.000  1.00  0.00           C\nATOM      3 C    ALA A   1       1.200   0.500   0.000  1.00  0.00           C\nATOM      4 O    ALA A   1       1.200   1.700   0.000  1.00  0.00           O\nATOM      5 N    ALA A   2       2.600   0.500   0.000  1.00  0.00           N\nATOM      6 CA   ALA A   2       3.800   0.000   0.000  1.00  0.00           C\nATOM      7 C    ALA A   2       5.000   0.500   0.000  1.00  0.00           C\nATOM      8 O    ALA A   2       5.000   1.700   0.000  1.00  0.00           O\nATOM      9 N    ALA A   3       6.400   0.500   0.000  1.00  0.00           N\nATOM     10 CA   ALA A   3       7.600   0.000   0.000  1.00  0.00           C\nATOM     11 C    ALA A   3       8.800   0.500   0.000  1.00  0.00           C\nATOM     12 O    ALA A   3       8.800   1.700   0.000  1.00  0.00           O\nATOM     13 N    ALA A   4      10.200   0.500   0.000  1.00  0.00           N\nATOM     14 CA   ALA A   4      11.400   0.000   0.000  1.00  0.00           C\nATOM     15 C    ALA A   4      12.600   0.500   0.000  1.00  0.00           C\nATOM     16 O    ALA A   4      12.600   1.700   0.000  1.00  0.00           O\nATOM     17 N    ALA A   5      14.000   0.500   0.000  1.00  0.00           N\nATOM     18 CA   ALA A   5      15.200   0.000   0.000  1.00  0.00           C\nATOM     19 C    ALA A   5      16.400   0.500   0.000  1.00  0.00           C\nATOM     20 O    ALA A   5      16.400   1.700   0.000  1.00  0.00           O\nATOM     21 N    ALA A   6      17.800   0.500   0.000  1.00  0.00           N\nATOM     22 CA   ALA A   6      19.000   0.000   0.000  1.00  0.00           C\nATOM     23 C    ALA A   6      20.200   0.500   0.000  1.00  0.00           C\nATOM     24 O    ALA A   6      20.200   1.700   0.000  1.00  0.00           O\nATOM     25 N    ALA A   7      21.600   0.500   0.000  1.00  0.00           N\nATOM     26 CA   ALA A   7      22.800   0.000   0.000  1.00  0.00           C\nATOM     27 C    ALA A   7      24.000   0.500   0.000  1.00  0.00           C\nATOM     28 O    ALA A   7      24.000   1.700   0.000  1.00  0.00           O\nATOM     29 N    ALA A   8      25.400   0.500   0.000  1.00  0.00           N\nATOM     30 CA   ALA A   8      26.600   0.000   0.000  1.00  0.00           C\nATOM     31 C    ALA A   8      27.800   0.500   0.000  1.00  0.00           C\nATOM     32 O    ALA A   8      27.800   1.700   0.000  1.00  0.00           O\nTER\nEND"
-    },
-    {
-      "index": 2,
-      "id": "slice-2",
-      "label": "Frame 2",
-      "filename": "frame_2.pdb",
-      "rmsxColumn": "rmsx1",
-      "pdb": "ATOM      1 N    ALA A   1      -1.200   0.500   0.000  1.00  0.00           N\nATOM      2 CA   ALA A   1       0.000   0.000   0.000  1.00  0.00           C\nATOM      3 C    ALA A   1       1.200   0.500   0.000  1.00  0.00           C\nATOM      4 O    ALA A   1       1.200   1.700   0.000  1.00  0.00           O\nATOM      5 N    ALA A   2       2.600   0.500   0.000  1.00  0.00           N\nATOM      6 CA   ALA A   2       3.800   0.000   0.000  1.00  0.00           C\nATOM      7 C    ALA A   2       5.000   0.500   0.000  1.00  0.00           C\nATOM      8 O    ALA A   2       5.000   1.700   0.000  1.00  0.00           O\nATOM      9 N    ALA A   3       6.400   0.500   0.000  1.00  0.00           N\nATOM     10 CA   ALA A   3       7.600   0.000   0.000  1.00  0.00           C\nATOM     11 C    ALA A   3       8.800   0.500   0.000  1.00  0.00           C\nATOM     12 O    ALA A   3       8.800   1.700   0.000  1.00  0.00           O\nATOM     13 N    ALA A   4      10.200   0.500   0.000  1.00  0.00           N\nATOM     14 CA   ALA A   4      11.400   0.000   0.000  1.00  0.00           C\nATOM     15 C    ALA A   4      12.600   0.500   0.000  1.00  0.00           C\nATOM     16 O    ALA A   4      12.600   1.700   0.000  1.00  0.00           O\nATOM     17 N    ALA A   5      14.000   0.500   0.000  1.00  0.00           N\nATOM     18 CA   ALA A   5      15.200   0.000   0.000  1.00  0.00           C\nATOM     19 C    ALA A   5      16.400   0.500   0.000  1.00  0.00           C\nATOM     20 O    ALA A   5      16.400   1.700   0.000  1.00  0.00           O\nATOM     21 N    ALA A   6      17.800   0.500   0.000  1.00  0.00           N\nATOM     22 CA   ALA A   6      19.000   0.000   0.000  1.00  0.00           C\nATOM     23 C    ALA A   6      20.200   0.500   0.000  1.00  0.00           C\nATOM     24 O    ALA A   6      20.200   1.700   0.000  1.00  0.00           O\nATOM     25 N    ALA A   7      21.600   0.500   0.000  1.00  0.00           N\nATOM     26 CA   ALA A   7      22.800   0.000   0.000  1.00  0.00           C\nATOM     27 C    ALA A   7      24.000   0.500   0.000  1.00  0.00           C\nATOM     28 O    ALA A   7      24.000   1.700   0.000  1.00  0.00           O\nATOM     29 N    ALA A   8      25.400   0.500   0.000  1.00  0.00           N\nATOM     30 CA   ALA A   8      26.600   0.000   0.000  1.00  0.00           C\nATOM     31 C    ALA A   8      27.800   0.500   0.000  1.00  0.00           C\nATOM     32 O    ALA A   8      27.800   1.700   0.000  1.00  0.00           O\nTER\nEND"
-    },
-    {
-      "index": 3,
-      "id": "slice-3",
-      "label": "Frame 3",
-      "filename": "frame_3.pdb",
-      "rmsxColumn": "rmsx2",
-      "pdb": "ATOM      1 N    ALA A   1      -1.200   0.500   0.000  1.00  0.00           N\nATOM      2 CA   ALA A   1       0.000   0.000   0.000  1.00  0.00           C\nATOM      3 C    ALA A   1       1.200   0.500   0.000  1.00  0.00           C\nATOM      4 O    ALA A   1       1.200   1.700   0.000  1.00  0.00           O\nATOM      5 N    ALA A   2       2.600   0.500   0.000  1.00  0.00           N\nATOM      6 CA   ALA A   2       3.800   0.000   0.000  1.00  0.00           C\nATOM      7 C    ALA A   2       5.000   0.500   0.000  1.00  0.00           C\nATOM      8 O    ALA A   2       5.000   1.700   0.000  1.00  0.00           O\nATOM      9 N    ALA A   3       6.400   0.500   0.000  1.00  0.00           N\nATOM     10 CA   ALA A   3       7.600   0.000   0.000  1.00  0.00           C\nATOM     11 C    ALA A   3       8.800   0.500   0.000  1.00  0.00           C\nATOM     12 O    ALA A   3       8.800   1.700   0.000  1.00  0.00           O\nATOM     13 N    ALA A   4      10.200   0.500   0.000  1.00  0.00           N\nATOM     14 CA   ALA A   4      11.400   0.000   0.000  1.00  0.00           C\nATOM     15 C    ALA A   4      12.600   0.500   0.000  1.00  0.00           C\nATOM     16 O    ALA A   4      12.600   1.700   0.000  1.00  0.00           O\nATOM     17 N    ALA A   5      14.000   0.500   0.000  1.00  0.00           N\nATOM     18 CA   ALA A   5      15.200   0.000   0.000  1.00  0.00           C\nATOM     19 C    ALA A   5      16.400   0.500   0.000  1.00  0.00           C\nATOM     20 O    ALA A   5      16.400   1.700   0.000  1.00  0.00           O\nATOM     21 N    ALA A   6      17.800   0.500   0.000  1.00  0.00           N\nATOM     22 CA   ALA A   6      19.000   0.000   0.000  1.00  0.00           C\nATOM     23 C    ALA A   6      20.200   0.500   0.000  1.00  0.00           C\nATOM     24 O    ALA A   6      20.200   1.700   0.000  1.00  0.00           O\nATOM     25 N    ALA A   7      21.600   0.500   0.000  1.00  0.00           N\nATOM     26 CA   ALA A   7      22.800   0.000   0.000  1.00  0.00           C\nATOM     27 C    ALA A   7      24.000   0.500   0.000  1.00  0.00           C\nATOM     28 O    ALA A   7      24.000   1.700   0.000  1.00  0.00           O\nATOM     29 N    ALA A   8      25.400   0.500   0.000  1.00  0.00           N\nATOM     30 CA   ALA A   8      26.600   0.000   0.000  1.00  0.00           C\nATOM     31 C    ALA A   8      27.800   0.500   0.000  1.00  0.00           C\nATOM     32 O    ALA A   8      27.800   1.700   0.000  1.00  0.00           O\nTER\nEND"
-    }
-  ],
-  "residues": [
-    {
-      "key": "A:1",
-      "id": "1",
-      "label": "ALA1",
-      "values": {
-        "rmsx0": 0.5,
-        "rmsx1": 0.822,
-        "rmsx2": 0.993
-      }
-    },
-    {
-      "key": "A:2",
-      "id": "2",
-      "label": "ALA2",
-      "values": {
-        "rmsx0": 0.822,
-        "rmsx1": 0.993,
-        "rmsx2": 0.932
-      }
-    },
-    {
-      "key": "A:3",
-      "id": "3",
-      "label": "ALA3",
-      "values": {
-        "rmsx0": 0.993,
-        "rmsx1": 0.932,
-        "rmsx2": 0.667
-      }
-    },
-    {
-      "key": "A:4",
-      "id": "4",
-      "label": "ALA4",
-      "values": {
-        "rmsx0": 0.932,
-        "rmsx1": 0.667,
-        "rmsx2": 0.325
-      }
-    },
-    {
-      "key": "A:5",
-      "id": "5",
-      "label": "ALA5",
-      "values": {
-        "rmsx0": 0.667,
-        "rmsx1": 0.325,
-        "rmsx2": 0.064
-      }
-    },
-    {
-      "key": "A:6",
-      "id": "6",
-      "label": "ALA6",
-      "values": {
-        "rmsx0": 0.325,
-        "rmsx1": 0.064,
-        "rmsx2": 0.009
-      }
-    },
-    {
-      "key": "A:7",
-      "id": "7",
-      "label": "ALA7",
-      "values": {
-        "rmsx0": 0.064,
-        "rmsx1": 0.009,
-        "rmsx2": 0.184
-      }
-    },
-    {
-      "key": "A:8",
-      "id": "8",
-      "label": "ALA8",
-      "values": {
-        "rmsx0": 0.009,
-        "rmsx1": 0.184,
-        "rmsx2": 0.508
-      }
-    }
-  ],
-  "summaries": {},
-  "domain": {
-    "min": 0,
-    "max": 1
-  },
-  "maskSummary": {
-    "maskedResidues": 0,
-    "totalResidues": 8,
-    "maskedKeys": []
-  },
-  "maskOpacity": 0.3,
-  "palette": {
-    "name": "viridis",
-    "colors": [
-      "#440154",
-      "#21918c",
-      "#fde725"
-    ]
-  },
   "availablePalettes": {
+    "cividis": [
+      "#00204D",
+      "#00306F",
+      "#2A406C",
+      "#48526B",
+      "#5E626E",
+      "#727374",
+      "#878479",
+      "#9E9677",
+      "#B6A971",
+      "#D0BE67",
+      "#EAD357",
+      "#FFEA46"
+    ],
+    "inferno": [
+      "#000004",
+      "#140B35",
+      "#3A0963",
+      "#60136E",
+      "#85216B",
+      "#A92E5E",
+      "#CB4149",
+      "#E65D2F",
+      "#F78311",
+      "#FCAD12",
+      "#F5DB4B",
+      "#FCFFA4"
+    ],
+    "magma": [
+      "#000004",
+      "#120D32",
+      "#331068",
+      "#5A167E",
+      "#7D2482",
+      "#A3307E",
+      "#C83E73",
+      "#E95562",
+      "#F97C5D",
+      "#FEA873",
+      "#FED395",
+      "#FCFDBF"
+    ],
+    "mako": [
+      "#0B0405",
+      "#231526",
+      "#35264C",
+      "#403A75",
+      "#3D526D",
+      "#366DA0",
+      "#3487A6",
+      "#35A1AB",
+      "#43BBAD",
+      "#6CD3AD",
+      "#ADE3C0",
+      "#DEF5E5"
+    ],
+    "plasma": [
+      "#0D0887",
+      "#3E049C",
+      "#6300A7",
+      "#8707A6",
+      "#A62098",
+      "#C03A83",
+      "#D5546E",
+      "#E76F5A",
+      "#F58C46",
+      "#FDAD32",
+      "#FCD225",
+      "#F0F921"
+    ],
+    "rocket": [
+      "#03051A",
+      "#221331",
+      "#451C47",
+      "#6A1F56",
+      "#921C5B",
+      "#B91657",
+      "#D92847",
+      "#ED513E",
+      "#F47C56",
+      "#F6A47B",
+      "#F7C9AA",
+      "#FAEBDD"
+    ],
+    "turbo": [
+      "#30123B",
+      "#4454C4",
+      "#4490FE",
+      "#1FC8DE",
+      "#29EFA2",
+      "#7DFF56",
+      "#C1F334",
+      "#F1CA3A",
+      "#FE922A",
+      "#EA4F0D",
+      "#BE2102",
+      "#7A0403"
+    ],
     "viridis": [
       "#440154",
-      "#21918c",
-      "#fde725"
+      "#482173",
+      "#433E85",
+      "#38598C",
+      "#2D708E",
+      "#25858E",
+      "#1E9B8A",
+      "#2BB07F",
+      "#51C56A",
+      "#85D54A",
+      "#C2DF23",
+      "#FDE725"
     ]
   },
+  "citation": {
+    "doi": "10.1038/s41598-026-39869-7",
+    "text": "RMSX/Flipbook paper, Scientific Reports (2026)",
+    "url": "https://doi.org/10.1038/s41598-026-39869-7"
+  },
+  "domain": {
+    "max": 9.605904465648072,
+    "min": 0
+  },
+  "flipbookReference": {
+    "colorStops": [
+      {
+        "bfactor": 0,
+        "color": "#440154"
+      },
+      {
+        "bfactor": 0.87,
+        "color": "#482173"
+      },
+      {
+        "bfactor": 1.75,
+        "color": "#433E85"
+      },
+      {
+        "bfactor": 2.62,
+        "color": "#38598C"
+      },
+      {
+        "bfactor": 3.49,
+        "color": "#2D708E"
+      },
+      {
+        "bfactor": 4.37,
+        "color": "#25858E"
+      },
+      {
+        "bfactor": 5.24,
+        "color": "#1E9B8A"
+      },
+      {
+        "bfactor": 6.11,
+        "color": "#2BB07F"
+      },
+      {
+        "bfactor": 6.99,
+        "color": "#51C56A"
+      },
+      {
+        "bfactor": 7.86,
+        "color": "#85D54A"
+      },
+      {
+        "bfactor": 8.73,
+        "color": "#C2DF23"
+      },
+      {
+        "bfactor": 9.61,
+        "color": "#FDE725"
+      }
+    ],
+    "commands": [
+      "view",
+      "define axis",
+      "turn x 90",
+      "color byattribute bfactor",
+      "worm bfactor",
+      "lighting soft",
+      "graphics silhouettes true",
+      "set bgColor white",
+      "color byattribute a:bfactor #1-9 target absc palette 0.0,#440154:0.87,#482173:1.75,#433E85:2.62,#38598C:3.49,#2D708E:4.37,#25858E:5.24,#1E9B8A:6.11,#2BB07F:6.99,#51C56A:7.86,#85D54A:8.73,#C2DF23:9.61,#FDE725",
+      "tile all columns 9 spacingFactor 1"
+    ],
+    "defaultColumns": 9,
+    "defaultSpacingFactor": 1,
+    "maximumSpacingFactor": 2.5,
+    "minimumSpacingFactor": 0,
+    "palette": "viridis",
+    "tilePaddingFactor": 1.55,
+    "viewer": "chimerax"
+  },
+  "keyboardShortcuts": {
+    "bindings": [
+      {
+        "action": "rotate all visible slices around display X by +/-5 degrees",
+        "keys": [
+          "u",
+          "i"
+        ]
+      },
+      {
+        "action": "rotate all visible slices around display Y by +/-5 degrees",
+        "keys": [
+          "n",
+          "m"
+        ]
+      },
+      {
+        "action": "rotate all visible slices around display Z by +/-5 degrees",
+        "keys": [
+          "j",
+          "k"
+        ]
+      },
+      {
+        "action": "adjust tiled spacing factor",
+        "keys": [
+          "=",
+          "+",
+          "-"
+        ]
+      },
+      {
+        "action": "adjust RMSX worm thickness scale",
+        "keys": [
+          "[",
+          "]"
+        ]
+      },
+      {
+        "action": "adjust RMSX color/radius domain",
+        "keys": [
+          ",",
+          "."
+        ]
+      },
+      {
+        "action": "step the active Flipbook slice",
+        "keys": [
+          "ArrowLeft",
+          "ArrowRight"
+        ]
+      },
+      {
+        "action": "switch tiled, overlay, and Flip layouts",
+        "keys": [
+          "t",
+          "o",
+          "f"
+        ]
+      }
+    ],
+    "enabled": true,
+    "rotationStepDegrees": 5,
+    "source": "VMD Flipbook hotkey parity subset",
+    "spacingStep": 0.05,
+    "thicknessStep": 0.05
+  },
+  "maskOpacity": 0.3,
+  "maskSummary": {
+    "masked": [],
+    "maskedKeys": [],
+    "maskedResidues": 0,
+    "totalResidues": 76
+  },
+  "molstar": {
+    "cssUrl": "https://cdn.jsdelivr.net/npm/molstar@5.4.2/build/viewer/molstar.css",
+    "jsUrl": "https://cdn.jsdelivr.net/npm/molstar@5.4.2/build/viewer/molstar.js",
+    "stateTransformsUrl": "https://cdn.jsdelivr.net/npm/molstar@5.4.2/lib/mol-plugin-state/transforms.js",
+    "stateTransformsUrls": [
+      "https://esm.sh/molstar@5.4.2/lib/mol-plugin-state/transforms.js?bundle",
+      "https://cdn.jsdelivr.net/npm/molstar@5.4.2/lib/mol-plugin-state/transforms.js"
+    ],
+    "version": "5.4.2"
+  },
+  "molstarRenderStyle": {
+    "ambientOcclusion": false,
+    "backgroundColor": "#ffffff",
+    "illumination": false,
+    "multiSample": false,
+    "outline": true,
+    "outlineDisableUrlParam": "outline=0",
+    "outlineUrlParam": "outline=1",
+    "preset": "clean-interactive",
+    "softLightingUrlParam": "render=soft"
+  },
+  "palette": {
+    "colors": [
+      "#440154",
+      "#482173",
+      "#433E85",
+      "#38598C",
+      "#2D708E",
+      "#25858E",
+      "#1E9B8A",
+      "#2BB07F",
+      "#51C56A",
+      "#85D54A",
+      "#C2DF23",
+      "#FDE725"
+    ],
+    "name": "viridis"
+  },
+  "playback": {
+    "defaultDelayMs": 900,
+    "delayStepMs": 50,
+    "delayUrlParam": "delayMs",
+    "maxDelayMs": 5000,
+    "minDelayMs": 150
+  },
   "presentation": {
-    "defaultLayout": "tiled"
+    "availableLayouts": [
+      "tiled",
+      "overlay",
+      "flip"
+    ],
+    "defaultLayout": "tiled",
+    "layoutUrlParam": "layout"
   },
-  "visualMapping": {
-    "defaultColorMin": 0,
-    "defaultColorMax": 1,
-    "defaultRadiusMin": 0.63,
-    "defaultRadiusMax": 3.18,
-    "defaultThicknessScale": 1,
-    "colorDomainStep": 0.1,
-    "radiusStep": 0.05
+  "reportPayload": {
+    "embeddedPdbBytes": 56538,
+    "embeddedPdbCount": 9,
+    "estimatedJsonBytes": 95422,
+    "largeReportWarningBytes": 10000000,
+    "largestEmbeddedPdbBytes": 6282,
+    "residueCount": 76,
+    "strategy": "self-contained Galaxy HTML with embedded PDB slices"
   },
+  "residues": [
+    {
+      "chain": "7",
+      "id": "1",
+      "key": "7:1",
+      "label": "1 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.812062886543252,
+        "slice_2.dcd": 5.771237730545767,
+        "slice_3.dcd": 6.540373671158701,
+        "slice_4.dcd": 6.862725038836389,
+        "slice_5.dcd": 6.057222022344902,
+        "slice_6.dcd": 5.904462675788819,
+        "slice_7.dcd": 5.6815417324833835,
+        "slice_8.dcd": 5.754769837379721,
+        "slice_9.dcd": 4.944134622750798
+      }
+    },
+    {
+      "chain": "7",
+      "id": "2",
+      "key": "7:2",
+      "label": "2 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.354323141136111,
+        "slice_2.dcd": 5.847273628520594,
+        "slice_3.dcd": 6.509542300690631,
+        "slice_4.dcd": 6.654650394698505,
+        "slice_5.dcd": 6.077676754760072,
+        "slice_6.dcd": 5.604273816065137,
+        "slice_7.dcd": 5.465019848901439,
+        "slice_8.dcd": 5.8373227583478755,
+        "slice_9.dcd": 4.759679464073875
+      }
+    },
+    {
+      "chain": "7",
+      "id": "3",
+      "key": "7:3",
+      "label": "3 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.443107844500763,
+        "slice_2.dcd": 5.9173988083249816,
+        "slice_3.dcd": 6.367408174159685,
+        "slice_4.dcd": 6.285600949047048,
+        "slice_5.dcd": 6.006851324177253,
+        "slice_6.dcd": 5.786825202416494,
+        "slice_7.dcd": 5.44209098442886,
+        "slice_8.dcd": 5.740180811490047,
+        "slice_9.dcd": 4.756303441894755
+      }
+    },
+    {
+      "chain": "7",
+      "id": "4",
+      "key": "7:4",
+      "label": "4 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.596942915141017,
+        "slice_2.dcd": 5.785491819193564,
+        "slice_3.dcd": 6.517357615225162,
+        "slice_4.dcd": 6.556576826261191,
+        "slice_5.dcd": 5.810086781868717,
+        "slice_6.dcd": 5.567266823778595,
+        "slice_7.dcd": 5.35579857296272,
+        "slice_8.dcd": 5.703892952536373,
+        "slice_9.dcd": 4.735059316531292
+      }
+    },
+    {
+      "chain": "7",
+      "id": "5",
+      "key": "7:5",
+      "label": "5 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.445769314157991,
+        "slice_2.dcd": 5.5389837254390075,
+        "slice_3.dcd": 6.419027448801537,
+        "slice_4.dcd": 6.4029712583496865,
+        "slice_5.dcd": 5.798098377313015,
+        "slice_6.dcd": 5.608477964039911,
+        "slice_7.dcd": 5.425664582361331,
+        "slice_8.dcd": 5.843440641391947,
+        "slice_9.dcd": 4.66828616758574
+      }
+    },
+    {
+      "chain": "7",
+      "id": "6",
+      "key": "7:6",
+      "label": "6 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.7889053614283394,
+        "slice_2.dcd": 5.613457466469309,
+        "slice_3.dcd": 6.590725626215487,
+        "slice_4.dcd": 6.215419679669513,
+        "slice_5.dcd": 5.716666311044332,
+        "slice_6.dcd": 5.603412766579552,
+        "slice_7.dcd": 5.526387048461386,
+        "slice_8.dcd": 5.675205892300744,
+        "slice_9.dcd": 4.6594511962523
+      }
+    },
+    {
+      "chain": "7",
+      "id": "7",
+      "key": "7:7",
+      "label": "7 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.839362373484904,
+        "slice_2.dcd": 6.009566348120251,
+        "slice_3.dcd": 7.095703695296351,
+        "slice_4.dcd": 6.720468683188189,
+        "slice_5.dcd": 5.616944887275358,
+        "slice_6.dcd": 5.403243132205202,
+        "slice_7.dcd": 5.19837239839579,
+        "slice_8.dcd": 5.734321719255165,
+        "slice_9.dcd": 4.670360760067712
+      }
+    },
+    {
+      "chain": "7",
+      "id": "8",
+      "key": "7:8",
+      "label": "8 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.252766803170053,
+        "slice_2.dcd": 6.422666316637038,
+        "slice_3.dcd": 6.999006016926021,
+        "slice_4.dcd": 6.071024521598365,
+        "slice_5.dcd": 5.826083356770033,
+        "slice_6.dcd": 5.379510721431145,
+        "slice_7.dcd": 5.291976124819259,
+        "slice_8.dcd": 5.802668155411338,
+        "slice_9.dcd": 4.441700487016056
+      }
+    },
+    {
+      "chain": "7",
+      "id": "9",
+      "key": "7:9",
+      "label": "9 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.808249677768254,
+        "slice_2.dcd": 5.918336674819135,
+        "slice_3.dcd": 6.530772046765333,
+        "slice_4.dcd": 5.210933517376665,
+        "slice_5.dcd": 5.6502812599859755,
+        "slice_6.dcd": 5.307437976642772,
+        "slice_7.dcd": 5.286387682274392,
+        "slice_8.dcd": 5.90389289883403,
+        "slice_9.dcd": 4.48821624953166
+      }
+    },
+    {
+      "chain": "7",
+      "id": "10",
+      "key": "7:10",
+      "label": "10 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.757877969580919,
+        "slice_2.dcd": 6.24197888394228,
+        "slice_3.dcd": 6.0900586108068095,
+        "slice_4.dcd": 5.343128902068563,
+        "slice_5.dcd": 5.625825537412682,
+        "slice_6.dcd": 5.380518987875137,
+        "slice_7.dcd": 5.148403114705486,
+        "slice_8.dcd": 5.7980996262583355,
+        "slice_9.dcd": 4.518840429157683
+      }
+    },
+    {
+      "chain": "7",
+      "id": "11",
+      "key": "7:11",
+      "label": "11 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.783715495374098,
+        "slice_2.dcd": 5.875655566943895,
+        "slice_3.dcd": 6.054340219305592,
+        "slice_4.dcd": 4.589894678815006,
+        "slice_5.dcd": 5.6775127609862235,
+        "slice_6.dcd": 5.685261888798625,
+        "slice_7.dcd": 5.104285669448873,
+        "slice_8.dcd": 5.939104909110521,
+        "slice_9.dcd": 4.219466899422942
+      }
+    },
+    {
+      "chain": "7",
+      "id": "12",
+      "key": "7:12",
+      "label": "12 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.555708557133837,
+        "slice_2.dcd": 5.88785803302078,
+        "slice_3.dcd": 5.815945606206819,
+        "slice_4.dcd": 4.763128506570699,
+        "slice_5.dcd": 5.589489918192174,
+        "slice_6.dcd": 5.534743225943249,
+        "slice_7.dcd": 5.02765872281118,
+        "slice_8.dcd": 5.8951169315612,
+        "slice_9.dcd": 4.431246943645472
+      }
+    },
+    {
+      "chain": "7",
+      "id": "13",
+      "key": "7:13",
+      "label": "13 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.307771668165492,
+        "slice_2.dcd": 5.589652094021187,
+        "slice_3.dcd": 4.619794138257459,
+        "slice_4.dcd": 4.548623570086649,
+        "slice_5.dcd": 5.502773870058647,
+        "slice_6.dcd": 5.517736308922526,
+        "slice_7.dcd": 5.141622173467357,
+        "slice_8.dcd": 5.883088427589409,
+        "slice_9.dcd": 4.635149885831137
+      }
+    },
+    {
+      "chain": "7",
+      "id": "14",
+      "key": "7:14",
+      "label": "14 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.09031094587534,
+        "slice_2.dcd": 5.475791578588687,
+        "slice_3.dcd": 3.9147380968066727,
+        "slice_4.dcd": 4.371012061066769,
+        "slice_5.dcd": 5.451592779672141,
+        "slice_6.dcd": 5.780188462366367,
+        "slice_7.dcd": 5.072250015121543,
+        "slice_8.dcd": 6.126135362409583,
+        "slice_9.dcd": 4.103030528593778
+      }
+    },
+    {
+      "chain": "7",
+      "id": "15",
+      "key": "7:15",
+      "label": "15 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.7941500986778824,
+        "slice_2.dcd": 4.456664709008834,
+        "slice_3.dcd": 2.9868090250349573,
+        "slice_4.dcd": 3.9497433144915357,
+        "slice_5.dcd": 5.482258930816257,
+        "slice_6.dcd": 5.7200226994004435,
+        "slice_7.dcd": 4.843290548052298,
+        "slice_8.dcd": 5.948869711323879,
+        "slice_9.dcd": 4.292228448097416
+      }
+    },
+    {
+      "chain": "7",
+      "id": "16",
+      "key": "7:16",
+      "label": "16 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.6824570121057336,
+        "slice_2.dcd": 3.8154315116024518,
+        "slice_3.dcd": 2.3778329049890394,
+        "slice_4.dcd": 4.1492953931684236,
+        "slice_5.dcd": 4.943834350284777,
+        "slice_6.dcd": 5.663136529978932,
+        "slice_7.dcd": 4.907829803727974,
+        "slice_8.dcd": 5.737488198616499,
+        "slice_9.dcd": 4.338631218025771
+      }
+    },
+    {
+      "chain": "7",
+      "id": "17",
+      "key": "7:17",
+      "label": "17 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.4640096523098336,
+        "slice_2.dcd": 3.1716910324441954,
+        "slice_3.dcd": 2.341605713682888,
+        "slice_4.dcd": 3.9193855031747984,
+        "slice_5.dcd": 4.961948071326658,
+        "slice_6.dcd": 5.541419067149704,
+        "slice_7.dcd": 4.878211743813885,
+        "slice_8.dcd": 5.776555140435695,
+        "slice_9.dcd": 4.044934894851756
+      }
+    },
+    {
+      "chain": "7",
+      "id": "18",
+      "key": "7:18",
+      "label": "18 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.4512937115423266,
+        "slice_2.dcd": 3.1715803630969743,
+        "slice_3.dcd": 2.329666555588351,
+        "slice_4.dcd": 3.9472644829819243,
+        "slice_5.dcd": 4.711725572649502,
+        "slice_6.dcd": 5.69925032538594,
+        "slice_7.dcd": 5.030936259537444,
+        "slice_8.dcd": 5.782119933612696,
+        "slice_9.dcd": 4.080774281510414
+      }
+    },
+    {
+      "chain": "7",
+      "id": "19",
+      "key": "7:19",
+      "label": "19 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.607232929983124,
+        "slice_2.dcd": 2.963271673634509,
+        "slice_3.dcd": 2.406304577166768,
+        "slice_4.dcd": 4.030678048336642,
+        "slice_5.dcd": 4.867209753393142,
+        "slice_6.dcd": 5.413340722381302,
+        "slice_7.dcd": 5.004905046894381,
+        "slice_8.dcd": 5.838652528647859,
+        "slice_9.dcd": 4.084956818484821
+      }
+    },
+    {
+      "chain": "7",
+      "id": "20",
+      "key": "7:20",
+      "label": "20 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.142470077263665,
+        "slice_2.dcd": 2.857008484177552,
+        "slice_3.dcd": 2.3695584225832533,
+        "slice_4.dcd": 3.770183756774882,
+        "slice_5.dcd": 4.475551537150496,
+        "slice_6.dcd": 5.0822104666275205,
+        "slice_7.dcd": 4.984405070757659,
+        "slice_8.dcd": 5.753952183244477,
+        "slice_9.dcd": 3.7312034960868274
+      }
+    },
+    {
+      "chain": "7",
+      "id": "21",
+      "key": "7:21",
+      "label": "21 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.053078602170816,
+        "slice_2.dcd": 2.6805999204527837,
+        "slice_3.dcd": 2.3121472424031917,
+        "slice_4.dcd": 3.182562079398824,
+        "slice_5.dcd": 4.9369509494081205,
+        "slice_6.dcd": 4.950707139498002,
+        "slice_7.dcd": 4.8866818640264125,
+        "slice_8.dcd": 5.6631052706145715,
+        "slice_9.dcd": 3.821979293900421
+      }
+    },
+    {
+      "chain": "7",
+      "id": "22",
+      "key": "7:22",
+      "label": "22 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.94219965606892,
+        "slice_2.dcd": 2.490330662631452,
+        "slice_3.dcd": 2.173318672566387,
+        "slice_4.dcd": 2.913873943808658,
+        "slice_5.dcd": 4.755518191607733,
+        "slice_6.dcd": 4.851110423979529,
+        "slice_7.dcd": 5.198979299241062,
+        "slice_8.dcd": 5.427423130316301,
+        "slice_9.dcd": 3.882978200394627
+      }
+    },
+    {
+      "chain": "7",
+      "id": "23",
+      "key": "7:23",
+      "label": "23 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.2259988867339944,
+        "slice_2.dcd": 2.380060021749322,
+        "slice_3.dcd": 2.1188291177042475,
+        "slice_4.dcd": 2.721943986277195,
+        "slice_5.dcd": 4.552372681697629,
+        "slice_6.dcd": 4.54059591742142,
+        "slice_7.dcd": 5.019018639484693,
+        "slice_8.dcd": 5.456354154882305,
+        "slice_9.dcd": 3.61925664387577
+      }
+    },
+    {
+      "chain": "7",
+      "id": "24",
+      "key": "7:24",
+      "label": "24 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.8541212278626964,
+        "slice_2.dcd": 2.473219852337029,
+        "slice_3.dcd": 2.079352184950319,
+        "slice_4.dcd": 2.6499071366961333,
+        "slice_5.dcd": 5.082658612510713,
+        "slice_6.dcd": 4.388203120184304,
+        "slice_7.dcd": 4.975202158490969,
+        "slice_8.dcd": 5.403566569911384,
+        "slice_9.dcd": 3.7597913944666517
+      }
+    },
+    {
+      "chain": "7",
+      "id": "25",
+      "key": "7:25",
+      "label": "25 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.6507356355940668,
+        "slice_2.dcd": 2.7692862443772257,
+        "slice_3.dcd": 2.1790953878029393,
+        "slice_4.dcd": 3.1801886048554433,
+        "slice_5.dcd": 4.511018536781193,
+        "slice_6.dcd": 3.498538459777724,
+        "slice_7.dcd": 4.874916802307839,
+        "slice_8.dcd": 5.449328445176562,
+        "slice_9.dcd": 3.6282025993798244
+      }
+    },
+    {
+      "chain": "7",
+      "id": "26",
+      "key": "7:26",
+      "label": "26 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.1307506744234797,
+        "slice_2.dcd": 2.806025536350459,
+        "slice_3.dcd": 2.2796168572198554,
+        "slice_4.dcd": 3.312713821705836,
+        "slice_5.dcd": 3.9186960062348426,
+        "slice_6.dcd": 3.6643076354471353,
+        "slice_7.dcd": 4.884390921529669,
+        "slice_8.dcd": 5.839081207181155,
+        "slice_9.dcd": 2.8226345154343044
+      }
+    },
+    {
+      "chain": "7",
+      "id": "27",
+      "key": "7:27",
+      "label": "27 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.270828258050369,
+        "slice_2.dcd": 2.6017387567612844,
+        "slice_3.dcd": 2.265344945918139,
+        "slice_4.dcd": 2.8994495417263844,
+        "slice_5.dcd": 4.078605146334345,
+        "slice_6.dcd": 3.2957139528253814,
+        "slice_7.dcd": 4.860193997677983,
+        "slice_8.dcd": 5.840713046563028,
+        "slice_9.dcd": 2.8461012472572844
+      }
+    },
+    {
+      "chain": "7",
+      "id": "28",
+      "key": "7:28",
+      "label": "28 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.7855807611239,
+        "slice_2.dcd": 2.736835632474907,
+        "slice_3.dcd": 2.290113479842319,
+        "slice_4.dcd": 3.136494698969032,
+        "slice_5.dcd": 4.157705313758632,
+        "slice_6.dcd": 3.3375438596367815,
+        "slice_7.dcd": 4.984115347193424,
+        "slice_8.dcd": 4.50784368936238,
+        "slice_9.dcd": 3.0103417001959727
+      }
+    },
+    {
+      "chain": "7",
+      "id": "29",
+      "key": "7:29",
+      "label": "29 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.883888951305748,
+        "slice_2.dcd": 3.056515280833735,
+        "slice_3.dcd": 2.383131240629755,
+        "slice_4.dcd": 3.763085911631538,
+        "slice_5.dcd": 3.3924814784786927,
+        "slice_6.dcd": 2.8266602422751363,
+        "slice_7.dcd": 4.622099589183242,
+        "slice_8.dcd": 4.730237840429488,
+        "slice_9.dcd": 3.1507845617320163
+      }
+    },
+    {
+      "chain": "7",
+      "id": "30",
+      "key": "7:30",
+      "label": "30 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.523548653594684,
+        "slice_2.dcd": 3.0773457360300998,
+        "slice_3.dcd": 2.3767890663889575,
+        "slice_4.dcd": 3.7234128777123585,
+        "slice_5.dcd": 3.130648976171029,
+        "slice_6.dcd": 2.7856101128149993,
+        "slice_7.dcd": 4.41828867592693,
+        "slice_8.dcd": 4.089151036497121,
+        "slice_9.dcd": 2.8197899858441278
+      }
+    },
+    {
+      "chain": "7",
+      "id": "31",
+      "key": "7:31",
+      "label": "31 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.3816914374675116,
+        "slice_2.dcd": 2.7240215233941827,
+        "slice_3.dcd": 2.333808255961637,
+        "slice_4.dcd": 3.5498294272609248,
+        "slice_5.dcd": 3.5328660360259114,
+        "slice_6.dcd": 3.3188465554479216,
+        "slice_7.dcd": 4.569531548103611,
+        "slice_8.dcd": 4.412634920199219,
+        "slice_9.dcd": 2.7532539794554065
+      }
+    },
+    {
+      "chain": "7",
+      "id": "32",
+      "key": "7:32",
+      "label": "32 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.152923915055734,
+        "slice_2.dcd": 3.2035744622094087,
+        "slice_3.dcd": 2.5961509111166197,
+        "slice_4.dcd": 4.12591798509581,
+        "slice_5.dcd": 3.5316458072115102,
+        "slice_6.dcd": 3.142966167981564,
+        "slice_7.dcd": 3.880378634403373,
+        "slice_8.dcd": 4.612433972440715,
+        "slice_9.dcd": 2.690351678137517
+      }
+    },
+    {
+      "chain": "7",
+      "id": "33",
+      "key": "7:33",
+      "label": "33 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.6343215499303745,
+        "slice_2.dcd": 3.838367033057702,
+        "slice_3.dcd": 2.6839020459330123,
+        "slice_4.dcd": 4.694187336173754,
+        "slice_5.dcd": 3.529180867886467,
+        "slice_6.dcd": 2.730187938713371,
+        "slice_7.dcd": 3.218134702221716,
+        "slice_8.dcd": 4.344895973712277,
+        "slice_9.dcd": 2.5043797668961516
+      }
+    },
+    {
+      "chain": "7",
+      "id": "34",
+      "key": "7:34",
+      "label": "34 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.2289245724216755,
+        "slice_2.dcd": 3.721619054470954,
+        "slice_3.dcd": 2.763975125338503,
+        "slice_4.dcd": 4.617616566476853,
+        "slice_5.dcd": 3.405347447241321,
+        "slice_6.dcd": 3.1333752561966453,
+        "slice_7.dcd": 2.3585778577931724,
+        "slice_8.dcd": 4.446131142570293,
+        "slice_9.dcd": 2.4377840344699773
+      }
+    },
+    {
+      "chain": "7",
+      "id": "35",
+      "key": "7:35",
+      "label": "35 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.050749353104563,
+        "slice_2.dcd": 3.0063280186188863,
+        "slice_3.dcd": 2.7625809176683758,
+        "slice_4.dcd": 4.268259588754232,
+        "slice_5.dcd": 3.4986644312990864,
+        "slice_6.dcd": 3.3952858905438235,
+        "slice_7.dcd": 2.2508156878929864,
+        "slice_8.dcd": 4.038908515592215,
+        "slice_9.dcd": 2.3609337174330354
+      }
+    },
+    {
+      "chain": "7",
+      "id": "36",
+      "key": "7:36",
+      "label": "36 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.341793095673527,
+        "slice_2.dcd": 3.0214119528877625,
+        "slice_3.dcd": 2.329176036995618,
+        "slice_4.dcd": 3.6076607487437853,
+        "slice_5.dcd": 3.187959329576621,
+        "slice_6.dcd": 2.661676565113639,
+        "slice_7.dcd": 2.1831824659479877,
+        "slice_8.dcd": 3.881369232794467,
+        "slice_9.dcd": 2.39096942601235
+      }
+    },
+    {
+      "chain": "7",
+      "id": "37",
+      "key": "7:37",
+      "label": "37 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.108883301804322,
+        "slice_2.dcd": 2.4943592675686457,
+        "slice_3.dcd": 2.1014979196466053,
+        "slice_4.dcd": 3.1177647003998175,
+        "slice_5.dcd": 3.122881891625667,
+        "slice_6.dcd": 2.547985121244578,
+        "slice_7.dcd": 2.3264477682449303,
+        "slice_8.dcd": 3.9734054553298277,
+        "slice_9.dcd": 2.088385901962322
+      }
+    },
+    {
+      "chain": "7",
+      "id": "38",
+      "key": "7:38",
+      "label": "38 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.731343220914466,
+        "slice_2.dcd": 2.019618049293146,
+        "slice_3.dcd": 1.8418003731302732,
+        "slice_4.dcd": 2.6710633079129087,
+        "slice_5.dcd": 2.6544224876129205,
+        "slice_6.dcd": 2.361545647053571,
+        "slice_7.dcd": 2.3036828221130023,
+        "slice_8.dcd": 4.0650324060161935,
+        "slice_9.dcd": 2.2079557559155787
+      }
+    },
+    {
+      "chain": "7",
+      "id": "39",
+      "key": "7:39",
+      "label": "39 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.132726493229313,
+        "slice_2.dcd": 2.415450187897894,
+        "slice_3.dcd": 1.8331949595288968,
+        "slice_4.dcd": 2.466189341496249,
+        "slice_5.dcd": 2.5077316449637133,
+        "slice_6.dcd": 1.8834574951650782,
+        "slice_7.dcd": 2.4719717949969144,
+        "slice_8.dcd": 4.230700099952404,
+        "slice_9.dcd": 2.10445978344515
+      }
+    },
+    {
+      "chain": "7",
+      "id": "40",
+      "key": "7:40",
+      "label": "40 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.5132998810366685,
+        "slice_2.dcd": 2.9447843424186284,
+        "slice_3.dcd": 1.769754964764151,
+        "slice_4.dcd": 2.578051712003424,
+        "slice_5.dcd": 2.540753428844283,
+        "slice_6.dcd": 2.11577548489647,
+        "slice_7.dcd": 2.36958957146798,
+        "slice_8.dcd": 4.246856114283048,
+        "slice_9.dcd": 2.128312498884229
+      }
+    },
+    {
+      "chain": "7",
+      "id": "41",
+      "key": "7:41",
+      "label": "41 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.069000555966278,
+        "slice_2.dcd": 2.3052167356939344,
+        "slice_3.dcd": 1.8265524222752616,
+        "slice_4.dcd": 2.3632042437492724,
+        "slice_5.dcd": 2.2418686819180453,
+        "slice_6.dcd": 2.463977170124331,
+        "slice_7.dcd": 2.250521837694326,
+        "slice_8.dcd": 2.8574656423561287,
+        "slice_9.dcd": 1.8916227283994247
+      }
+    },
+    {
+      "chain": "7",
+      "id": "42",
+      "key": "7:42",
+      "label": "42 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.8838985401269692,
+        "slice_2.dcd": 2.1161574764507907,
+        "slice_3.dcd": 1.6575466634890557,
+        "slice_4.dcd": 2.080415935079016,
+        "slice_5.dcd": 1.8545343428760914,
+        "slice_6.dcd": 2.1435693822451536,
+        "slice_7.dcd": 2.2329297946425983,
+        "slice_8.dcd": 3.086640021938314,
+        "slice_9.dcd": 1.7373636248358568
+      }
+    },
+    {
+      "chain": "7",
+      "id": "43",
+      "key": "7:43",
+      "label": "43 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.1609479545214394,
+        "slice_2.dcd": 2.4840387131067265,
+        "slice_3.dcd": 1.7116740987499826,
+        "slice_4.dcd": 2.5111505877491354,
+        "slice_5.dcd": 1.929352155611634,
+        "slice_6.dcd": 1.9379938575019613,
+        "slice_7.dcd": 2.20912755770397,
+        "slice_8.dcd": 3.1969500345974393,
+        "slice_9.dcd": 1.6014074970022987
+      }
+    },
+    {
+      "chain": "7",
+      "id": "44",
+      "key": "7:44",
+      "label": "44 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.4570032038533953,
+        "slice_2.dcd": 2.7936575235134717,
+        "slice_3.dcd": 1.5932100391310864,
+        "slice_4.dcd": 2.1382731016883088,
+        "slice_5.dcd": 1.5170756158933039,
+        "slice_6.dcd": 1.7491314778632696,
+        "slice_7.dcd": 2.236714049460568,
+        "slice_8.dcd": 2.855908275697279,
+        "slice_9.dcd": 1.416134401676729
+      }
+    },
+    {
+      "chain": "7",
+      "id": "45",
+      "key": "7:45",
+      "label": "45 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.032205929622854,
+        "slice_2.dcd": 2.3682973586667297,
+        "slice_3.dcd": 1.3129123084381673,
+        "slice_4.dcd": 1.6086246385026142,
+        "slice_5.dcd": 1.168972935167213,
+        "slice_6.dcd": 1.4970881771147453,
+        "slice_7.dcd": 2.203911226175108,
+        "slice_8.dcd": 2.1919033824301866,
+        "slice_9.dcd": 1.0754932338445424
+      }
+    },
+    {
+      "chain": "7",
+      "id": "46",
+      "key": "7:46",
+      "label": "46 / chain 7",
+      "values": {
+        "slice_1.dcd": 1.5317962720356175,
+        "slice_2.dcd": 2.408667950298225,
+        "slice_3.dcd": 1.8268385138839185,
+        "slice_4.dcd": 2.1022745897714668,
+        "slice_5.dcd": 1.2669552556348231,
+        "slice_6.dcd": 1.6845466309345167,
+        "slice_7.dcd": 2.0277059827264177,
+        "slice_8.dcd": 2.4693186044775164,
+        "slice_9.dcd": 0.9546620541473692
+      }
+    },
+    {
+      "chain": "7",
+      "id": "47",
+      "key": "7:47",
+      "label": "47 / chain 7",
+      "values": {
+        "slice_1.dcd": 1.0504964111531232,
+        "slice_2.dcd": 1.4242333244317584,
+        "slice_3.dcd": 1.3375457321244117,
+        "slice_4.dcd": 1.38312286928144,
+        "slice_5.dcd": 0.7082029322706073,
+        "slice_6.dcd": 0.97355238540562,
+        "slice_7.dcd": 1.6746759552565798,
+        "slice_8.dcd": 1.7142426759291511,
+        "slice_9.dcd": 0.7057200205666936
+      }
+    },
+    {
+      "chain": "7",
+      "id": "48",
+      "key": "7:48",
+      "label": "48 / chain 7",
+      "values": {
+        "slice_1.dcd": 0,
+        "slice_2.dcd": 0,
+        "slice_3.dcd": 0,
+        "slice_4.dcd": 0,
+        "slice_5.dcd": 0,
+        "slice_6.dcd": 0,
+        "slice_7.dcd": 0,
+        "slice_8.dcd": 0,
+        "slice_9.dcd": 0
+      }
+    },
+    {
+      "chain": "7",
+      "id": "49",
+      "key": "7:49",
+      "label": "49 / chain 7",
+      "values": {
+        "slice_1.dcd": 1.1414419574456458,
+        "slice_2.dcd": 1.1824912484199348,
+        "slice_3.dcd": 0.7287338816277983,
+        "slice_4.dcd": 1.2775678157050598,
+        "slice_5.dcd": 0.7058010321313654,
+        "slice_6.dcd": 1.0152872193931386,
+        "slice_7.dcd": 1.526677048971859,
+        "slice_8.dcd": 1.2926668443768115,
+        "slice_9.dcd": 1.4088641193871818
+      }
+    },
+    {
+      "chain": "7",
+      "id": "50",
+      "key": "7:50",
+      "label": "50 / chain 7",
+      "values": {
+        "slice_1.dcd": 1.7444207750213387,
+        "slice_2.dcd": 1.605587113279679,
+        "slice_3.dcd": 0.8596059426780523,
+        "slice_4.dcd": 1.5670900471466978,
+        "slice_5.dcd": 0.990369887843675,
+        "slice_6.dcd": 1.6646724448911878,
+        "slice_7.dcd": 1.5083548737197117,
+        "slice_8.dcd": 1.4606567615058381,
+        "slice_9.dcd": 1.6596236131458624
+      }
+    },
+    {
+      "chain": "7",
+      "id": "51",
+      "key": "7:51",
+      "label": "51 / chain 7",
+      "values": {
+        "slice_1.dcd": 2.6854770787342157,
+        "slice_2.dcd": 1.7587843372565335,
+        "slice_3.dcd": 1.2002924819971013,
+        "slice_4.dcd": 1.7077350696549214,
+        "slice_5.dcd": 1.360162154783953,
+        "slice_6.dcd": 1.8368918128783929,
+        "slice_7.dcd": 1.526832056165548,
+        "slice_8.dcd": 2.027202712769629,
+        "slice_9.dcd": 2.403531298177118
+      }
+    },
+    {
+      "chain": "7",
+      "id": "52",
+      "key": "7:52",
+      "label": "52 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.0087191944660225,
+        "slice_2.dcd": 1.9107472344994896,
+        "slice_3.dcd": 1.8109868422606739,
+        "slice_4.dcd": 2.506445511824902,
+        "slice_5.dcd": 2.097761627793908,
+        "slice_6.dcd": 2.042695294317353,
+        "slice_7.dcd": 1.8019037288435742,
+        "slice_8.dcd": 2.441508383491519,
+        "slice_9.dcd": 2.8466435057949626
+      }
+    },
+    {
+      "chain": "7",
+      "id": "53",
+      "key": "7:53",
+      "label": "53 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.0737598572726874,
+        "slice_2.dcd": 2.4957662132514478,
+        "slice_3.dcd": 2.126712433478571,
+        "slice_4.dcd": 2.3997074428228595,
+        "slice_5.dcd": 1.718680030091032,
+        "slice_6.dcd": 1.945963874238378,
+        "slice_7.dcd": 1.624345399487314,
+        "slice_8.dcd": 2.6951626484395894,
+        "slice_9.dcd": 2.0792933398121987
+      }
+    },
+    {
+      "chain": "7",
+      "id": "54",
+      "key": "7:54",
+      "label": "54 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.2534163263448104,
+        "slice_2.dcd": 2.012986383419732,
+        "slice_3.dcd": 2.1962603235529388,
+        "slice_4.dcd": 2.6896777604173465,
+        "slice_5.dcd": 1.652006766681803,
+        "slice_6.dcd": 1.9378758269553806,
+        "slice_7.dcd": 1.9171108126754697,
+        "slice_8.dcd": 2.9475855790067143,
+        "slice_9.dcd": 1.9304265639001306
+      }
+    },
+    {
+      "chain": "7",
+      "id": "55",
+      "key": "7:55",
+      "label": "55 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.2324325290740425,
+        "slice_2.dcd": 2.241031044330576,
+        "slice_3.dcd": 2.290776483090029,
+        "slice_4.dcd": 3.038049864774303,
+        "slice_5.dcd": 1.6162439848389307,
+        "slice_6.dcd": 2.0165315494208826,
+        "slice_7.dcd": 1.9154282124205282,
+        "slice_8.dcd": 3.1050110664331836,
+        "slice_9.dcd": 2.0082320095806097
+      }
+    },
+    {
+      "chain": "7",
+      "id": "56",
+      "key": "7:56",
+      "label": "56 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.5933793403701535,
+        "slice_2.dcd": 2.560197632686889,
+        "slice_3.dcd": 2.507790456383255,
+        "slice_4.dcd": 3.227008359448076,
+        "slice_5.dcd": 1.5678763405428822,
+        "slice_6.dcd": 2.522483330376834,
+        "slice_7.dcd": 2.0832391521721307,
+        "slice_8.dcd": 3.1823465392817303,
+        "slice_9.dcd": 2.4615806116198535
+      }
+    },
+    {
+      "chain": "7",
+      "id": "57",
+      "key": "7:57",
+      "label": "57 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.7527044859599505,
+        "slice_2.dcd": 2.6394216255811553,
+        "slice_3.dcd": 2.702984203729648,
+        "slice_4.dcd": 3.5286119702692846,
+        "slice_5.dcd": 1.8524687783572313,
+        "slice_6.dcd": 2.208336609960941,
+        "slice_7.dcd": 2.4080747215249936,
+        "slice_8.dcd": 3.3944611999145993,
+        "slice_9.dcd": 2.639511293412687
+      }
+    },
+    {
+      "chain": "7",
+      "id": "58",
+      "key": "7:58",
+      "label": "58 / chain 7",
+      "values": {
+        "slice_1.dcd": 3.7435811774734855,
+        "slice_2.dcd": 2.434989809818994,
+        "slice_3.dcd": 2.800154580311951,
+        "slice_4.dcd": 3.119714744351216,
+        "slice_5.dcd": 2.6587275544978923,
+        "slice_6.dcd": 2.2516316850606395,
+        "slice_7.dcd": 2.461613722256975,
+        "slice_8.dcd": 3.3770727093057715,
+        "slice_9.dcd": 2.5585071851472154
+      }
+    },
+    {
+      "chain": "7",
+      "id": "59",
+      "key": "7:59",
+      "label": "59 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.191259984170504,
+        "slice_2.dcd": 2.7390448727289733,
+        "slice_3.dcd": 2.9384654645070682,
+        "slice_4.dcd": 2.96017920437162,
+        "slice_5.dcd": 2.810644426132425,
+        "slice_6.dcd": 2.140570256658897,
+        "slice_7.dcd": 2.823883476553796,
+        "slice_8.dcd": 3.3684755489312592,
+        "slice_9.dcd": 2.3649550556268824
+      }
+    },
+    {
+      "chain": "7",
+      "id": "60",
+      "key": "7:60",
+      "label": "60 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.377989428662339,
+        "slice_2.dcd": 3.0773483723940145,
+        "slice_3.dcd": 3.194579320872754,
+        "slice_4.dcd": 3.40416789231116,
+        "slice_5.dcd": 2.873942017844411,
+        "slice_6.dcd": 2.2859713708016085,
+        "slice_7.dcd": 2.8237418736952002,
+        "slice_8.dcd": 3.6912116941223743,
+        "slice_9.dcd": 2.8695416354934915
+      }
+    },
+    {
+      "chain": "7",
+      "id": "61",
+      "key": "7:61",
+      "label": "61 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.43255662362524,
+        "slice_2.dcd": 3.2424354034713083,
+        "slice_3.dcd": 2.9338251616222757,
+        "slice_4.dcd": 3.4976631855704383,
+        "slice_5.dcd": 2.7995247375963173,
+        "slice_6.dcd": 2.4533890553132536,
+        "slice_7.dcd": 2.66695872976308,
+        "slice_8.dcd": 3.5551696527973684,
+        "slice_9.dcd": 3.1814743928414972
+      }
+    },
+    {
+      "chain": "7",
+      "id": "62",
+      "key": "7:62",
+      "label": "62 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.644438224616678,
+        "slice_2.dcd": 3.489566881837834,
+        "slice_3.dcd": 2.887009486319188,
+        "slice_4.dcd": 4.0308382689425954,
+        "slice_5.dcd": 2.7314463497882153,
+        "slice_6.dcd": 2.921981384369769,
+        "slice_7.dcd": 2.4863382679409596,
+        "slice_8.dcd": 3.348137317994571,
+        "slice_9.dcd": 2.9491167111433025
+      }
+    },
+    {
+      "chain": "7",
+      "id": "63",
+      "key": "7:63",
+      "label": "63 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.824151678960044,
+        "slice_2.dcd": 3.7500802712744084,
+        "slice_3.dcd": 2.678089238796399,
+        "slice_4.dcd": 4.037062993066012,
+        "slice_5.dcd": 3.0018742783353414,
+        "slice_6.dcd": 2.994901751329119,
+        "slice_7.dcd": 2.417595208232087,
+        "slice_8.dcd": 3.3662598716961623,
+        "slice_9.dcd": 3.276740399044487
+      }
+    },
+    {
+      "chain": "7",
+      "id": "64",
+      "key": "7:64",
+      "label": "64 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.076929731083379,
+        "slice_2.dcd": 4.8145747720534855,
+        "slice_3.dcd": 2.83066882096164,
+        "slice_4.dcd": 4.174910406359163,
+        "slice_5.dcd": 3.6246478310359334,
+        "slice_6.dcd": 3.2987366887292238,
+        "slice_7.dcd": 2.6257718818763567,
+        "slice_8.dcd": 3.276316892953182,
+        "slice_9.dcd": 3.521261077903741
+      }
+    },
+    {
+      "chain": "7",
+      "id": "65",
+      "key": "7:65",
+      "label": "65 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.122018015654638,
+        "slice_2.dcd": 5.047540307393882,
+        "slice_3.dcd": 3.0986473889153268,
+        "slice_4.dcd": 4.327972613753267,
+        "slice_5.dcd": 3.55370005483025,
+        "slice_6.dcd": 3.508552658353639,
+        "slice_7.dcd": 2.648159972420221,
+        "slice_8.dcd": 3.6270096890793115,
+        "slice_9.dcd": 4.349596326151812
+      }
+    },
+    {
+      "chain": "7",
+      "id": "66",
+      "key": "7:66",
+      "label": "66 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.057226685902958,
+        "slice_2.dcd": 5.369326120592239,
+        "slice_3.dcd": 3.2447332370248256,
+        "slice_4.dcd": 4.053547743706658,
+        "slice_5.dcd": 2.897255490681959,
+        "slice_6.dcd": 4.036818143827493,
+        "slice_7.dcd": 2.618817297515136,
+        "slice_8.dcd": 3.7528850327213004,
+        "slice_9.dcd": 4.584746636859094
+      }
+    },
+    {
+      "chain": "7",
+      "id": "67",
+      "key": "7:67",
+      "label": "67 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.793626628701401,
+        "slice_2.dcd": 4.932964424732177,
+        "slice_3.dcd": 3.1741969347004475,
+        "slice_4.dcd": 3.4496564887550827,
+        "slice_5.dcd": 2.701820834040372,
+        "slice_6.dcd": 3.396031425828308,
+        "slice_7.dcd": 2.333902707817344,
+        "slice_8.dcd": 3.559506821055864,
+        "slice_9.dcd": 4.030309583545645
+      }
+    },
+    {
+      "chain": "7",
+      "id": "68",
+      "key": "7:68",
+      "label": "68 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.038614853115558,
+        "slice_2.dcd": 5.230269687862428,
+        "slice_3.dcd": 3.51532852323176,
+        "slice_4.dcd": 3.422768828811937,
+        "slice_5.dcd": 2.363090264025951,
+        "slice_6.dcd": 3.4012315175157783,
+        "slice_7.dcd": 2.6006275543061155,
+        "slice_8.dcd": 3.2550043519403085,
+        "slice_9.dcd": 3.4848711336345333
+      }
+    },
+    {
+      "chain": "7",
+      "id": "69",
+      "key": "7:69",
+      "label": "69 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.6122321286569745,
+        "slice_2.dcd": 4.856146013080017,
+        "slice_3.dcd": 3.2850408265929985,
+        "slice_4.dcd": 3.2563181127797027,
+        "slice_5.dcd": 2.393999259296848,
+        "slice_6.dcd": 3.117529249760231,
+        "slice_7.dcd": 3.0234105446602593,
+        "slice_8.dcd": 3.2970313874930746,
+        "slice_9.dcd": 3.0063008647085137
+      }
+    },
+    {
+      "chain": "7",
+      "id": "70",
+      "key": "7:70",
+      "label": "70 / chain 7",
+      "values": {
+        "slice_1.dcd": 4.868831224003339,
+        "slice_2.dcd": 4.832279043146525,
+        "slice_3.dcd": 2.653644413759054,
+        "slice_4.dcd": 3.2164626572532513,
+        "slice_5.dcd": 3.08751267286685,
+        "slice_6.dcd": 2.628757824538243,
+        "slice_7.dcd": 3.0738396614130146,
+        "slice_8.dcd": 3.4224325985839936,
+        "slice_9.dcd": 2.4878053073265054
+      }
+    },
+    {
+      "chain": "7",
+      "id": "71",
+      "key": "7:71",
+      "label": "71 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.187894768765604,
+        "slice_2.dcd": 4.201783758800947,
+        "slice_3.dcd": 2.7511837915430757,
+        "slice_4.dcd": 2.968605708987818,
+        "slice_5.dcd": 3.245412427809338,
+        "slice_6.dcd": 2.4904879777791034,
+        "slice_7.dcd": 3.6097599598581684,
+        "slice_8.dcd": 3.4834839952629753,
+        "slice_9.dcd": 2.531641273253561
+      }
+    },
+    {
+      "chain": "7",
+      "id": "72",
+      "key": "7:72",
+      "label": "72 / chain 7",
+      "values": {
+        "slice_1.dcd": 5.3890967998025125,
+        "slice_2.dcd": 4.412205547231568,
+        "slice_3.dcd": 2.7524326135551935,
+        "slice_4.dcd": 2.9946154701530077,
+        "slice_5.dcd": 3.147834923838077,
+        "slice_6.dcd": 2.615320512542993,
+        "slice_7.dcd": 3.3931188536938186,
+        "slice_8.dcd": 3.7232023981378757,
+        "slice_9.dcd": 2.631703021664713
+      }
+    },
+    {
+      "chain": "7",
+      "id": "73",
+      "key": "7:73",
+      "label": "73 / chain 7",
+      "values": {
+        "slice_1.dcd": 6.53290822358818,
+        "slice_2.dcd": 5.333342060189718,
+        "slice_3.dcd": 3.473587746344015,
+        "slice_4.dcd": 3.5865734562061395,
+        "slice_5.dcd": 3.47960813178503,
+        "slice_6.dcd": 2.3715765576493255,
+        "slice_7.dcd": 2.91155881353351,
+        "slice_8.dcd": 4.31722691572685,
+        "slice_9.dcd": 2.9936066759521687
+      }
+    },
+    {
+      "chain": "7",
+      "id": "74",
+      "key": "7:74",
+      "label": "74 / chain 7",
+      "values": {
+        "slice_1.dcd": 6.935848259341772,
+        "slice_2.dcd": 5.5728085373945575,
+        "slice_3.dcd": 3.2550167510323686,
+        "slice_4.dcd": 3.788819107557385,
+        "slice_5.dcd": 3.4801946354076527,
+        "slice_6.dcd": 2.3752601870292103,
+        "slice_7.dcd": 2.2763988526555092,
+        "slice_8.dcd": 3.6878331768113948,
+        "slice_9.dcd": 3.0720463503071325
+      }
+    },
+    {
+      "chain": "7",
+      "id": "75",
+      "key": "7:75",
+      "label": "75 / chain 7",
+      "values": {
+        "slice_1.dcd": 7.956002277201058,
+        "slice_2.dcd": 7.498435015310242,
+        "slice_3.dcd": 3.740876215214293,
+        "slice_4.dcd": 4.650735108598801,
+        "slice_5.dcd": 3.6233842075314997,
+        "slice_6.dcd": 2.480404736920409,
+        "slice_7.dcd": 2.645325399140059,
+        "slice_8.dcd": 4.297226328867713,
+        "slice_9.dcd": 3.8356927602684117
+      }
+    },
+    {
+      "chain": "7",
+      "id": "76",
+      "key": "7:76",
+      "label": "76 / chain 7",
+      "values": {
+        "slice_1.dcd": 7.333020550436898,
+        "slice_2.dcd": 9.605904465648072,
+        "slice_3.dcd": 3.9166040796620987,
+        "slice_4.dcd": 6.125895426912157,
+        "slice_5.dcd": 3.850767264520945,
+        "slice_6.dcd": 3.2443129803527766,
+        "slice_7.dcd": 4.421295261541758,
+        "slice_8.dcd": 5.330576965748491,
+        "slice_9.dcd": 4.560517126683992
+      }
+    }
+  ],
   "rotationModel": {
     "defaultRotation": {
       "x": 90,
       "y": 0,
       "z": 0
+    },
+    "defaultRotationSource": "ChimeraX Flipbook command: turn x 90",
+    "dragSemantics": "convert Molstar screen-axis drag deltas into coordinate-space rotation matrices, then apply the same delta independently to every visible slice",
+    "layoutOrder": "rotate around local center, then place that center on a shared Flipbook slot anchor plus tile offset",
+    "mode": "per-slice local coordinate transform",
+    "pivot": "geometric center of each full slice before mask splitting",
+    "verticalDragSign": "screen dy is applied directly around the current screen-right axis"
+  },
+  "schemaVersion": "flipbook-molstar-viewer/v1",
+  "selectedResidueMarker": {
+    "alpha": 0.86,
+    "color": "#111827",
+    "enabledDefault": false,
+    "residueUrlParam": "residue",
+    "sizeFactor": 0.36,
+    "toggleUrlParam": "marker",
+    "type": "spacefill"
+  },
+  "slices": [
+    {
+      "filename": "slice_1_first_frame.pdb",
+      "id": "slice_1",
+      "index": 1,
+      "label": "Slice 1",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1       7.800  -1.800  -0.300  1.00  4.81      7       \nATOM      2  CA  GLN X   2       4.100  -1.600  -0.800  1.00  4.35      7       \nATOM      3  CA  ILE X   3       2.900  -2.200  -4.400  1.00  4.44      7       \nATOM      4  CA  PHE X   4      -0.600  -3.100  -5.700  1.00  4.60      7       \nATOM      5  CA  VAL X   5      -1.800  -6.100  -7.900  1.00  4.45      7       \nATOM      6  CA  LYS X   6      -5.000  -5.300  -9.700  1.00  4.79      7       \nATOM      7  CA  THR X   7      -7.100  -7.600 -12.000  1.00  4.84      7       \nATOM      8  CA  LEU X   8      -8.700  -6.300 -15.200  1.00  5.25      7       \nATOM      9  CA  THR X   9     -12.100  -6.500 -13.600  1.00  4.81      7       \nATOM     10  CA  GLY X  10     -11.000  -4.600 -10.600  1.00  4.76      7       \nATOM     11  CA  LYS X  11      -9.700  -6.700  -7.600  1.00  4.78      7       \nATOM     12  CA  THR X  12      -6.900  -4.900  -5.800  1.00  4.56      7       \nATOM     13  CA  ILE X  13      -4.600  -6.700  -3.300  1.00  4.31      7       \nATOM     14  CA  THR X  14      -1.500  -5.300  -1.600  1.00  4.09      7       \nATOM     15  CA  LEU X  15       1.900  -6.900  -2.100  1.00  3.79      7       \nATOM     16  CA  GLU X  16       5.200  -6.500  -0.300  1.00  3.68      7       \nATOM     17  CA  VAL X  17       8.700  -7.100  -1.900  1.00  3.46      7       \nATOM     18  CA  GLU X  18      12.100  -5.300  -1.900  1.00  3.45      7       \nATOM     19  CA  PRO X  19      13.500  -3.600  -5.100  1.00  3.61      7       \nATOM     20  CA  SER X  20      16.100  -6.400  -5.400  1.00  3.14      7       \nATOM     21  CA  ASP X  21      13.700  -9.300  -5.000  1.00  3.05      7       \nATOM     22  CA  THR X  22      12.500 -10.800  -8.300  1.00  2.94      7       \nATOM     23  CA  ILE X  23       9.400 -11.300 -10.400  1.00  3.23      7       \nATOM     24  CA  GLU X  24       9.600 -15.000  -9.500  1.00  2.85      7       \nATOM     25  CA  ASN X  25       8.800 -13.900  -5.900  1.00  2.65      7       \nATOM     26  CA  VAL X  26       5.900 -11.600  -7.000  1.00  3.13      7       \nATOM     27  CA  LYS X  27       4.600 -14.700  -8.900  1.00  3.27      7       \nATOM     28  CA  ALA X  28       5.000 -16.900  -5.800  1.00  2.79      7       \nATOM     29  CA  LYS X  29       3.200 -14.500  -3.400  1.00  2.88      7       \nATOM     30  CA  ILE X  30       0.300 -13.800  -5.800  1.00  3.52      7       \nATOM     31  CA  GLN X  31       0.200 -17.600  -6.200  1.00  3.38      7       \nATOM     32  CA  ASP X  32       0.100 -18.200  -2.400  1.00  3.15      7       \nATOM     33  CA  LYS X  33      -2.800 -15.900  -1.500  1.00  3.63      7       \nATOM     34  CA  GLU X  34      -5.000 -16.400  -4.600  1.00  4.23      7       \nATOM     35  CA  GLY X  35      -4.000 -19.900  -5.900  1.00  4.05      7       \nATOM     36  CA  ILE X  36      -3.000 -18.600  -9.400  1.00  4.34      7       \nATOM     37  CA  PRO X  37       0.000 -20.700 -10.900  1.00  4.11      7       \nATOM     38  CA  PRO X  38       3.000 -19.000 -12.600  1.00  3.73      7       \nATOM     39  CA  ASP X  39       2.200 -19.600 -16.300  1.00  4.13      7       \nATOM     40  CA  GLN X  40      -1.300 -17.800 -15.900  1.00  4.51      7       \nATOM     41  CA  GLN X  41      -0.100 -14.600 -14.100  1.00  4.07      7       \nATOM     42  CA  ARG X  42       0.600 -12.200 -16.900  1.00  3.88      7       \nATOM     43  CA  LEU X  43       1.900  -9.300 -15.000  1.00  3.16      7       \nATOM     44  CA  ILE X  44       1.700  -6.000 -17.000  1.00  2.46      7       \nATOM     45  CA  PHE X  45       3.500  -2.900 -15.700  1.00  2.03      7       \nATOM     46  CA  ALA X  46       2.600   0.300 -17.700  1.00  1.53      7       \nATOM     47  CA  GLY X  47       2.800  -1.100 -21.300  1.00  1.05      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       5.000  -7.600 -19.600  1.00  1.14      7       \nATOM     50  CA  LEU X  50       7.200  -8.500 -16.700  1.00  1.74      7       \nATOM     51  CA  GLU X  51       9.500 -11.500 -17.100  1.00  2.69      7       \nATOM     52  CA  ASP X  52      10.400 -13.800 -14.100  1.00  3.01      7       \nATOM     53  CA  GLY X  53      14.100 -13.900 -13.600  1.00  3.07      7       \nATOM     54  CA  ARG X  54      14.600 -10.200 -13.700  1.00  3.25      7       \nATOM     55  CA  THR X  55      14.200  -8.000 -10.600  1.00  3.23      7       \nATOM     56  CA  LEU X  56      11.600  -5.200  -9.700  1.00  3.59      7       \nATOM     57  CA  SER X  57      14.900  -3.000  -9.800  1.00  3.75      7       \nATOM     58  CA  ASP X  58      15.700  -3.900 -13.500  1.00  3.74      7       \nATOM     59  CA  TYR X  59      12.300  -2.600 -14.600  1.00  4.19      7       \nATOM     60  CA  ASN X  60      12.600   0.400 -12.100  1.00  4.38      7       \nATOM     61  CA  ILE X  61       9.500  -0.300  -9.900  1.00  4.43      7       \nATOM     62  CA  GLN X  62       9.100   1.800  -6.600  1.00  4.64      7       \nATOM     63  CA  LYS X  63       6.400   1.700  -3.800  1.00  4.82      7       \nATOM     64  CA  GLU X  64       2.700   2.500  -4.600  1.00  5.08      7       \nATOM     65  CA  SER X  65       2.900   1.000  -8.100  1.00  5.12      7       \nATOM     66  CA  THR X  66       0.100  -1.000  -9.700  1.00  5.06      7       \nATOM     67  CA  LEU X  67       0.900  -4.300 -11.500  1.00  4.79      7       \nATOM     68  CA  HSE X  68      -1.900  -5.300 -13.600  1.00  5.04      7       \nATOM     69  CA  LEU X  69      -2.900  -8.800 -13.300  1.00  4.61      7       \nATOM     70  CA  VAL X  70      -3.700 -10.200 -16.700  1.00  4.87      7       \nATOM     71  CA  LEU X  71      -4.700 -13.900 -16.600  1.00  5.19      7       \nATOM     72  CA  ARG X  72      -3.900 -16.000 -19.600  1.00  5.39      7       \nATOM     73  CA  LEU X  73      -5.400 -19.500 -20.000  1.00  6.53      7       \nATOM     74  CA  ARG X  74      -4.400 -22.400 -22.100  1.00  6.94      7       \nATOM     75  CA  GLY X  75      -5.800 -25.900 -22.900  1.00  7.96      7       \nATOM     76  CA  GLY X  76      -8.200 -27.400 -25.400  1.00  7.33      7       \nEND\n",
+      "rmsxColumn": "slice_1.dcd"
+    },
+    {
+      "filename": "slice_2_first_frame.pdb",
+      "id": "slice_2",
+      "index": 2,
+      "label": "Slice 2",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1       6.400  -2.500  14.600  1.00  5.77      7       \nATOM      2  CA  GLN X   2       4.200  -2.600  11.500  1.00  5.85      7       \nATOM      3  CA  ILE X   3       3.300  -1.000   8.200  1.00  5.92      7       \nATOM      4  CA  PHE X   4      -0.200  -0.400   6.800  1.00  5.79      7       \nATOM      5  CA  VAL X   5      -1.800  -1.800   3.700  1.00  5.54      7       \nATOM      6  CA  LYS X   6      -4.600   0.200   2.100  1.00  5.61      7       \nATOM      7  CA  THR X   7      -6.600  -1.200  -0.800  1.00  6.01      7       \nATOM      8  CA  LEU X   8      -8.900   1.200  -2.800  1.00  6.42      7       \nATOM      9  CA  THR X   9     -12.000  -0.300  -1.100  1.00  5.92      7       \nATOM     10  CA  GLY X  10     -10.400   1.400   1.900  1.00  6.24      7       \nATOM     11  CA  LYS X  11      -9.700  -1.200   4.500  1.00  5.88      7       \nATOM     12  CA  THR X  12      -6.500  -0.200   6.300  1.00  5.89      7       \nATOM     13  CA  ILE X  13      -5.000  -3.300   7.700  1.00  5.59      7       \nATOM     14  CA  THR X  14      -1.800  -3.700   9.700  1.00  5.48      7       \nATOM     15  CA  LEU X  15       1.000  -5.900   8.700  1.00  4.46      7       \nATOM     16  CA  GLU X  16       4.400  -6.700  10.500  1.00  3.82      7       \nATOM     17  CA  VAL X  17       7.400  -6.700   8.100  1.00  3.17      7       \nATOM     18  CA  GLU X  18      10.900  -5.200   7.500  1.00  3.17      7       \nATOM     19  CA  PRO X  19      11.400  -2.800   4.500  1.00  2.96      7       \nATOM     20  CA  SER X  20      14.300  -5.300   3.500  1.00  2.86      7       \nATOM     21  CA  ASP X  21      11.600  -7.800   2.600  1.00  2.68      7       \nATOM     22  CA  THR X  22      10.200  -8.200  -0.900  1.00  2.49      7       \nATOM     23  CA  ILE X  23       6.900  -7.300  -2.400  1.00  2.38      7       \nATOM     24  CA  GLU X  24       6.500 -11.100  -3.200  1.00  2.47      7       \nATOM     25  CA  ASN X  25       6.700 -11.900   0.600  1.00  2.77      7       \nATOM     26  CA  VAL X  26       4.000  -9.300   1.300  1.00  2.81      7       \nATOM     27  CA  LYS X  27       1.900 -11.200  -1.200  1.00  2.60      7       \nATOM     28  CA  ALA X  28       2.600 -14.400   0.700  1.00  2.74      7       \nATOM     29  CA  LYS X  29       1.800 -12.900   4.200  1.00  3.06      7       \nATOM     30  CA  ILE X  30      -1.400 -11.200   3.100  1.00  3.08      7       \nATOM     31  CA  GLN X  31      -2.500 -14.500   1.500  1.00  2.72      7       \nATOM     32  CA  ASP X  32      -1.900 -16.300   4.700  1.00  3.20      7       \nATOM     33  CA  LYS X  33      -3.800 -13.700   6.800  1.00  3.84      7       \nATOM     34  CA  GLU X  34      -6.600 -12.100   4.700  1.00  3.72      7       \nATOM     35  CA  GLY X  35      -6.800 -14.800   2.000  1.00  3.01      7       \nATOM     36  CA  ILE X  36      -6.100 -12.700  -1.100  1.00  3.02      7       \nATOM     37  CA  PRO X  37      -4.500 -14.600  -4.100  1.00  2.49      7       \nATOM     38  CA  PRO X  38      -1.000 -13.300  -5.100  1.00  2.02      7       \nATOM     39  CA  ASP X  39      -2.300 -12.800  -8.700  1.00  2.42      7       \nATOM     40  CA  GLN X  40      -5.300 -10.900  -7.200  1.00  2.94      7       \nATOM     41  CA  GLN X  41      -3.000  -8.700  -5.300  1.00  2.31      7       \nATOM     42  CA  ARG X  42      -1.900  -6.300  -8.200  1.00  2.12      7       \nATOM     43  CA  LEU X  43       0.300  -3.300  -8.600  1.00  2.48      7       \nATOM     44  CA  ILE X  44       0.100  -1.700 -12.200  1.00  2.79      7       \nATOM     45  CA  PHE X  45       2.800   0.600 -13.700  1.00  2.37      7       \nATOM     46  CA  ALA X  46       3.300   0.600 -17.500  1.00  2.41      7       \nATOM     47  CA  GLY X  47       2.200  -1.700 -20.400  1.00  1.42      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       5.800  -6.400 -17.700  1.00  1.18      7       \nATOM     50  CA  LEU X  50       6.700  -5.800 -14.000  1.00  1.61      7       \nATOM     51  CA  GLU X  51       8.700  -7.900 -11.300  1.00  1.76      7       \nATOM     52  CA  ASP X  52       7.700  -9.500  -7.900  1.00  1.91      7       \nATOM     53  CA  GLY X  53      11.000 -10.000  -6.000  1.00  2.50      7       \nATOM     54  CA  ARG X  54      12.100  -6.300  -5.300  1.00  2.01      7       \nATOM     55  CA  THR X  55      12.200  -4.700  -1.800  1.00  2.24      7       \nATOM     56  CA  LEU X  56       9.800  -2.500   0.100  1.00  2.56      7       \nATOM     57  CA  SER X  57      12.800   0.100   0.400  1.00  2.64      7       \nATOM     58  CA  ASP X  58      13.100   0.300  -3.400  1.00  2.43      7       \nATOM     59  CA  TYR X  59       9.400   1.000  -3.400  1.00  2.74      7       \nATOM     60  CA  ASN X  60      10.300   3.700  -0.800  1.00  3.08      7       \nATOM     61  CA  ILE X  61       8.200   2.400   2.200  1.00  3.24      7       \nATOM     62  CA  GLN X  62       9.400   2.800   5.900  1.00  3.49      7       \nATOM     63  CA  LYS X  63       7.800   1.600   9.100  1.00  3.75      7       \nATOM     64  CA  GLU X  64       4.300   3.000   9.800  1.00  4.81      7       \nATOM     65  CA  SER X  65       3.900   3.900   6.100  1.00  5.05      7       \nATOM     66  CA  THR X  66       1.000   3.000   3.700  1.00  5.37      7       \nATOM     67  CA  LEU X  67       1.400   0.400   0.900  1.00  4.93      7       \nATOM     68  CA  HSE X  68      -1.000   1.100  -2.000  1.00  5.23      7       \nATOM     69  CA  LEU X  69      -2.500  -2.100  -3.500  1.00  4.86      7       \nATOM     70  CA  VAL X  70      -4.800  -2.800  -6.400  1.00  4.83      7       \nATOM     71  CA  LEU X  71      -7.100  -5.800  -6.700  1.00  4.20      7       \nATOM     72  CA  ARG X  72      -8.000  -7.900  -9.800  1.00  4.41      7       \nATOM     73  CA  LEU X  73     -11.700  -8.500  -9.400  1.00  5.33      7       \nATOM     74  CA  ARG X  74     -13.800 -10.900 -11.700  1.00  5.57      7       \nATOM     75  CA  GLY X  75     -17.500 -10.600 -12.900  1.00  7.50      7       \nATOM     76  CA  GLY X  76     -20.100 -11.500 -15.500  1.00  9.61      7       \nEND\n",
+      "rmsxColumn": "slice_2.dcd"
+    },
+    {
+      "filename": "slice_3_first_frame.pdb",
+      "id": "slice_3",
+      "index": 3,
+      "label": "Slice 3",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1       7.600  -3.400  34.400  1.00  6.54      7       \nATOM      2  CA  GLN X   2       8.400  -4.100  30.600  1.00  6.51      7       \nATOM      3  CA  ILE X   3       6.700  -3.100  27.400  1.00  6.37      7       \nATOM      4  CA  PHE X   4       6.800  -4.400  23.800  1.00  6.52      7       \nATOM      5  CA  VAL X   5       5.600  -3.300  20.400  1.00  6.42      7       \nATOM      6  CA  LYS X   6       2.300  -3.900  18.600  1.00  6.59      7       \nATOM      7  CA  THR X   7       1.900  -5.600  15.200  1.00  7.10      7       \nATOM      8  CA  LEU X   8      -1.000  -4.300  13.100  1.00  7.00      7       \nATOM      9  CA  THR X   9      -4.000  -2.600  14.800  1.00  6.53      7       \nATOM     10  CA  GLY X  10      -4.400  -3.600  18.400  1.00  6.09      7       \nATOM     11  CA  LYS X  11      -2.600  -6.900  18.800  1.00  6.05      7       \nATOM     12  CA  THR X  12       0.400  -7.000  21.100  1.00  5.82      7       \nATOM     13  CA  ILE X  13       2.900  -9.500  19.700  1.00  4.62      7       \nATOM     14  CA  THR X  14       6.600  -9.100  18.500  1.00  3.91      7       \nATOM     15  CA  LEU X  15       7.400  -7.300  15.200  1.00  2.99      7       \nATOM     16  CA  GLU X  16      11.000  -8.700  15.000  1.00  2.38      7       \nATOM     17  CA  VAL X  17      11.700  -7.200  11.600  1.00  2.34      7       \nATOM     18  CA  GLU X  18      15.400  -6.900  10.300  1.00  2.33      7       \nATOM     19  CA  PRO X  19      15.800  -3.900   7.800  1.00  2.41      7       \nATOM     20  CA  SER X  20      18.200  -6.000   5.700  1.00  2.37      7       \nATOM     21  CA  ASP X  21      15.300  -8.200   4.500  1.00  2.31      7       \nATOM     22  CA  THR X  22      13.500  -7.700   1.100  1.00  2.17      7       \nATOM     23  CA  ILE X  23       9.800  -6.900   0.300  1.00  2.12      7       \nATOM     24  CA  GLU X  24       9.300 -10.500  -1.100  1.00  2.08      7       \nATOM     25  CA  ASN X  25      10.600 -12.000   2.100  1.00  2.18      7       \nATOM     26  CA  VAL X  26       8.400  -9.700   4.400  1.00  2.28      7       \nATOM     27  CA  LYS X  27       5.400 -10.300   2.200  1.00  2.27      7       \nATOM     28  CA  ALA X  28       5.800 -14.200   2.900  1.00  2.29      7       \nATOM     29  CA  LYS X  29       5.800 -13.700   6.600  1.00  2.38      7       \nATOM     30  CA  ILE X  30       2.800 -11.400   7.100  1.00  2.38      7       \nATOM     31  CA  GLN X  31       1.000 -13.700   4.700  1.00  2.33      7       \nATOM     32  CA  ASP X  32       1.600 -16.700   7.000  1.00  2.60      7       \nATOM     33  CA  LYS X  33       1.800 -15.300  10.500  1.00  2.68      7       \nATOM     34  CA  GLU X  34      -0.900 -12.700  10.700  1.00  2.76      7       \nATOM     35  CA  GLY X  35      -2.700 -14.000   7.600  1.00  2.76      7       \nATOM     36  CA  ILE X  36      -2.600 -11.000   5.200  1.00  2.33      7       \nATOM     37  CA  PRO X  37      -2.800 -12.000   1.500  1.00  2.10      7       \nATOM     38  CA  PRO X  38      -0.100 -10.200  -0.700  1.00  1.84      7       \nATOM     39  CA  ASP X  39      -2.300  -7.700  -2.400  1.00  1.83      7       \nATOM     40  CA  GLN X  40      -2.600  -5.500   0.700  1.00  1.77      7       \nATOM     41  CA  GLN X  41       0.700  -4.100  -0.800  1.00  1.83      7       \nATOM     42  CA  ARG X  42       1.600  -3.400  -4.500  1.00  1.66      7       \nATOM     43  CA  LEU X  43       2.100  -6.500  -7.000  1.00  1.71      7       \nATOM     44  CA  ILE X  44       3.400  -7.100 -10.600  1.00  1.59      7       \nATOM     45  CA  PHE X  45       2.400  -5.000 -13.600  1.00  1.31      7       \nATOM     46  CA  ALA X  46       0.500  -4.900 -16.800  1.00  1.83      7       \nATOM     47  CA  GLY X  47       1.800  -5.400 -20.400  1.00  1.34      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       8.000  -5.000 -17.900  1.00  0.73      7       \nATOM     50  CA  LEU X  50       8.200  -2.800 -14.800  1.00  0.86      7       \nATOM     51  CA  GLU X  51      10.500  -3.200 -11.800  1.00  1.20      7       \nATOM     52  CA  ASP X  52      10.900  -4.900  -8.300  1.00  1.81      7       \nATOM     53  CA  GLY X  53      11.000  -3.600  -4.700  1.00  2.13      7       \nATOM     54  CA  ARG X  54      14.000  -3.600  -2.600  1.00  2.20      7       \nATOM     55  CA  THR X  55      15.000  -3.800   1.100  1.00  2.29      7       \nATOM     56  CA  LEU X  56      13.000  -2.500   4.000  1.00  2.51      7       \nATOM     57  CA  SER X  57      16.300  -0.500   4.800  1.00  2.70      7       \nATOM     58  CA  ASP X  58      16.100   1.300   1.300  1.00  2.80      7       \nATOM     59  CA  TYR X  59      12.500   2.600   2.100  1.00  2.94      7       \nATOM     60  CA  ASN X  60      13.800   3.600   5.600  1.00  3.19      7       \nATOM     61  CA  ILE X  61      12.100   1.000   7.900  1.00  2.93      7       \nATOM     62  CA  GLN X  62      14.000   0.400  11.100  1.00  2.89      7       \nATOM     63  CA  LYS X  63      14.200  -1.900  14.100  1.00  2.68      7       \nATOM     64  CA  GLU X  64      15.000  -1.600  17.700  1.00  2.83      7       \nATOM     65  CA  SER X  65      12.400   1.300  18.600  1.00  3.10      7       \nATOM     66  CA  THR X  66       8.500   1.200  19.000  1.00  3.24      7       \nATOM     67  CA  LEU X  67       7.100   1.200  15.400  1.00  3.17      7       \nATOM     68  CA  HSE X  68       4.000  -0.500  14.100  1.00  3.52      7       \nATOM     69  CA  LEU X  69       3.400  -2.400  10.800  1.00  3.29      7       \nATOM     70  CA  VAL X  70       1.800   0.000   8.300  1.00  2.65      7       \nATOM     71  CA  LEU X  71       0.100  -1.700   5.200  1.00  2.75      7       \nATOM     72  CA  ARG X  72      -2.900  -0.700   3.300  1.00  2.75      7       \nATOM     73  CA  LEU X  73      -6.300  -0.600   5.200  1.00  3.47      7       \nATOM     74  CA  ARG X  74      -9.500  -2.200   3.800  1.00  3.26      7       \nATOM     75  CA  GLY X  75     -11.100  -2.600   7.300  1.00  3.74      7       \nATOM     76  CA  GLY X  76      -8.900  -2.300  10.400  1.00  3.92      7       \nEND\n",
+      "rmsxColumn": "slice_3.dcd"
+    },
+    {
+      "filename": "slice_4_first_frame.pdb",
+      "id": "slice_4",
+      "index": 4,
+      "label": "Slice 4",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1      11.600  -3.600  51.600  1.00  6.86      7       \nATOM      2  CA  GLN X   2      12.800  -4.500  48.000  1.00  6.65      7       \nATOM      3  CA  ILE X   3      10.700  -4.700  44.900  1.00  6.29      7       \nATOM      4  CA  PHE X   4      11.000  -6.100  41.200  1.00  6.56      7       \nATOM      5  CA  VAL X   5      11.800  -4.300  37.800  1.00  6.40      7       \nATOM      6  CA  LYS X   6      11.700  -5.500  34.200  1.00  6.22      7       \nATOM      7  CA  THR X   7      14.000  -4.900  31.300  1.00  6.72      7       \nATOM      8  CA  LEU X   8      13.700  -2.000  28.600  1.00  6.07      7       \nATOM      9  CA  THR X   9      10.200  -0.900  27.400  1.00  5.21      7       \nATOM     10  CA  GLY X  10       8.200  -4.100  27.800  1.00  5.34      7       \nATOM     11  CA  LYS X  11      10.300  -6.900  26.300  1.00  4.59      7       \nATOM     12  CA  THR X  12      13.700  -7.000  24.700  1.00  4.76      7       \nATOM     13  CA  ILE X  13      12.200  -8.300  21.300  1.00  4.55      7       \nATOM     14  CA  THR X  14      13.900  -7.400  17.900  1.00  4.37      7       \nATOM     15  CA  LEU X  15      12.700  -7.200  14.400  1.00  3.95      7       \nATOM     16  CA  GLU X  16      14.800  -9.100  11.900  1.00  4.15      7       \nATOM     17  CA  VAL X  17      16.100  -7.500   8.600  1.00  3.92      7       \nATOM     18  CA  GLU X  18      19.800  -7.500   7.400  1.00  3.95      7       \nATOM     19  CA  PRO X  19      21.100  -4.800   4.900  1.00  4.03      7       \nATOM     20  CA  SER X  20      22.000  -7.600   2.400  1.00  3.77      7       \nATOM     21  CA  ASP X  21      18.300  -8.400   2.100  1.00  3.18      7       \nATOM     22  CA  THR X  22      16.200  -7.500  -1.100  1.00  2.91      7       \nATOM     23  CA  ILE X  23      12.700  -6.000  -1.200  1.00  2.72      7       \nATOM     24  CA  GLU X  24      11.700  -9.300  -2.800  1.00  2.65      7       \nATOM     25  CA  ASN X  25      13.000 -11.200   0.300  1.00  3.18      7       \nATOM     26  CA  VAL X  26      11.000  -8.900   2.700  1.00  3.31      7       \nATOM     27  CA  LYS X  27       7.900  -9.000   0.400  1.00  2.90      7       \nATOM     28  CA  ALA X  28       8.000 -12.800   0.000  1.00  3.14      7       \nATOM     29  CA  LYS X  29       8.700 -13.300   3.800  1.00  3.76      7       \nATOM     30  CA  ILE X  30       5.500 -11.500   4.900  1.00  3.72      7       \nATOM     31  CA  GLN X  31       3.500 -13.700   2.400  1.00  3.55      7       \nATOM     32  CA  ASP X  32       4.700 -16.900   4.200  1.00  4.13      7       \nATOM     33  CA  LYS X  33       5.100 -15.600   7.700  1.00  4.69      7       \nATOM     34  CA  GLU X  34       2.300 -13.100   8.400  1.00  4.62      7       \nATOM     35  CA  GLY X  35      -0.100 -14.100   5.600  1.00  4.27      7       \nATOM     36  CA  ILE X  36      -0.900 -11.000   3.500  1.00  3.61      7       \nATOM     37  CA  PRO X  37      -2.000 -12.400   0.000  1.00  3.12      7       \nATOM     38  CA  PRO X  38       0.000 -11.300  -3.200  1.00  2.67      7       \nATOM     39  CA  ASP X  39      -3.000  -9.300  -4.700  1.00  2.47      7       \nATOM     40  CA  GLN X  40      -2.500  -6.600  -1.900  1.00  2.58      7       \nATOM     41  CA  GLN X  41       1.000  -5.800  -3.500  1.00  2.36      7       \nATOM     42  CA  ARG X  42       2.200  -4.400  -6.600  1.00  2.08      7       \nATOM     43  CA  LEU X  43       1.200  -6.700  -9.600  1.00  2.51      7       \nATOM     44  CA  ILE X  44       2.800  -7.000 -13.000  1.00  2.14      7       \nATOM     45  CA  PHE X  45       1.600  -5.800 -16.400  1.00  1.61      7       \nATOM     46  CA  ALA X  46       0.900  -7.900 -19.500  1.00  2.10      7       \nATOM     47  CA  GLY X  47       3.500  -6.900 -22.000  1.00  1.38      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       8.000  -4.500 -18.000  1.00  1.28      7       \nATOM     50  CA  LEU X  50       8.200  -4.300 -14.100  1.00  1.57      7       \nATOM     51  CA  GLU X  51      11.000  -2.000 -12.400  1.00  1.71      7       \nATOM     52  CA  ASP X  52      13.900  -3.400 -10.400  1.00  2.51      7       \nATOM     53  CA  GLY X  53      13.800  -3.900  -6.600  1.00  2.40      7       \nATOM     54  CA  ARG X  54      17.200  -3.700  -5.000  1.00  2.69      7       \nATOM     55  CA  THR X  55      18.900  -4.600  -1.600  1.00  3.04      7       \nATOM     56  CA  LEU X  56      18.400  -2.500   1.600  1.00  3.23      7       \nATOM     57  CA  SER X  57      22.200  -1.800   1.200  1.00  3.53      7       \nATOM     58  CA  ASP X  58      21.400   0.200  -2.100  1.00  3.12      7       \nATOM     59  CA  TYR X  59      18.500   2.300  -0.700  1.00  2.96      7       \nATOM     60  CA  ASN X  60      20.800   2.800   2.300  1.00  3.40      7       \nATOM     61  CA  ILE X  61      18.200   1.300   4.800  1.00  3.50      7       \nATOM     62  CA  GLN X  62      19.600   0.300   8.300  1.00  4.03      7       \nATOM     63  CA  LYS X  63      18.700  -2.300  10.900  1.00  4.04      7       \nATOM     64  CA  GLU X  64      18.600  -2.500  14.800  1.00  4.17      7       \nATOM     65  CA  SER X  65      16.200   0.300  15.800  1.00  4.33      7       \nATOM     66  CA  THR X  66      12.600   0.700  14.400  1.00  4.05      7       \nATOM     67  CA  LEU X  67      12.100  -0.100  10.800  1.00  3.45      7       \nATOM     68  CA  HSE X  68      11.000   2.700   8.300  1.00  3.42      7       \nATOM     69  CA  LEU X  69      10.400   0.600   5.100  1.00  3.26      7       \nATOM     70  CA  VAL X  70       6.800   1.300   3.700  1.00  3.22      7       \nATOM     71  CA  LEU X  71       5.100  -2.000   3.000  1.00  2.97      7       \nATOM     72  CA  ARG X  72       1.600  -2.700   1.500  1.00  2.99      7       \nATOM     73  CA  LEU X  73       0.100  -4.700   4.300  1.00  3.59      7       \nATOM     74  CA  ARG X  74      -3.600  -5.200   5.000  1.00  3.79      7       \nATOM     75  CA  GLY X  75      -4.000  -4.700   8.800  1.00  4.65      7       \nATOM     76  CA  GLY X  76      -0.800  -4.900  10.900  1.00  6.13      7       \nEND\n",
+      "rmsxColumn": "slice_4.dcd"
+    },
+    {
+      "filename": "slice_5_first_frame.pdb",
+      "id": "slice_5",
+      "index": 5,
+      "label": "Slice 5",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1      12.300   3.000  69.000  1.00  6.06      7       \nATOM      2  CA  GLN X   2      13.000   2.100  65.300  1.00  6.08      7       \nATOM      3  CA  ILE X   3      11.700   3.200  62.000  1.00  6.01      7       \nATOM      4  CA  PHE X   4      11.500   1.800  58.400  1.00  5.81      7       \nATOM      5  CA  VAL X   5      12.900   3.000  55.100  1.00  5.80      7       \nATOM      6  CA  LYS X   6      11.000   3.300  51.700  1.00  5.72      7       \nATOM      7  CA  THR X   7      11.800   1.700  48.200  1.00  5.62      7       \nATOM      8  CA  LEU X   8      12.200   3.100  44.600  1.00  5.83      7       \nATOM      9  CA  THR X   9      10.300   1.800  41.700  1.00  5.65      7       \nATOM     10  CA  GLY X  10      11.600   1.700  38.100  1.00  5.63      7       \nATOM     11  CA  LYS X  11      10.900   3.000  34.500  1.00  5.68      7       \nATOM     12  CA  THR X  12       8.400   1.700  31.900  1.00  5.59      7       \nATOM     13  CA  ILE X  13       9.300  -0.300  28.800  1.00  5.50      7       \nATOM     14  CA  THR X  14      10.500   1.200  25.600  1.00  5.45      7       \nATOM     15  CA  LEU X  15       9.800   0.500  22.000  1.00  5.48      7       \nATOM     16  CA  GLU X  16      11.500  -2.700  20.200  1.00  4.94      7       \nATOM     17  CA  VAL X  17      10.500  -2.600  16.500  1.00  4.96      7       \nATOM     18  CA  GLU X  18      12.100  -0.800  13.500  1.00  4.71      7       \nATOM     19  CA  PRO X  19      11.000   0.500  10.000  1.00  4.87      7       \nATOM     20  CA  SER X  20      13.100  -2.200   8.500  1.00  4.48      7       \nATOM     21  CA  ASP X  21      11.900  -4.300   5.500  1.00  4.94      7       \nATOM     22  CA  THR X  22      11.100  -3.900   1.800  1.00  4.76      7       \nATOM     23  CA  ILE X  23       7.400  -3.000   0.900  1.00  4.55      7       \nATOM     24  CA  GLU X  24       7.300  -6.400  -0.700  1.00  5.08      7       \nATOM     25  CA  ASN X  25       7.900  -8.300   2.500  1.00  4.51      7       \nATOM     26  CA  VAL X  26       5.200  -6.400   4.400  1.00  3.92      7       \nATOM     27  CA  LYS X  27       2.800  -6.700   1.300  1.00  4.08      7       \nATOM     28  CA  ALA X  28       3.400 -10.500   1.400  1.00  4.16      7       \nATOM     29  CA  LYS X  29       2.600 -10.600   5.300  1.00  3.39      7       \nATOM     30  CA  ILE X  30      -0.900  -8.600   4.900  1.00  3.13      7       \nATOM     31  CA  GLN X  31      -2.100 -10.800   2.000  1.00  3.53      7       \nATOM     32  CA  ASP X  32      -1.600 -13.900   4.000  1.00  3.53      7       \nATOM     33  CA  LYS X  33      -2.200 -13.300   7.700  1.00  3.53      7       \nATOM     34  CA  GLU X  34      -4.500 -10.300   7.800  1.00  3.41      7       \nATOM     35  CA  GLY X  35      -6.300 -10.600   4.300  1.00  3.50      7       \nATOM     36  CA  ILE X  36      -5.500  -7.500   2.300  1.00  3.19      7       \nATOM     37  CA  PRO X  37      -4.700  -8.600  -1.400  1.00  3.12      7       \nATOM     38  CA  PRO X  38      -2.000  -6.800  -3.500  1.00  2.65      7       \nATOM     39  CA  ASP X  39      -4.200  -4.700  -5.800  1.00  2.51      7       \nATOM     40  CA  GLN X  40      -4.900  -2.400  -2.800  1.00  2.54      7       \nATOM     41  CA  GLN X  41      -1.200  -1.400  -3.100  1.00  2.24      7       \nATOM     42  CA  ARG X  42       0.100  -1.100  -6.600  1.00  1.85      7       \nATOM     43  CA  LEU X  43      -0.900  -2.100 -10.200  1.00  1.93      7       \nATOM     44  CA  ILE X  44       0.400  -4.400 -12.900  1.00  1.52      7       \nATOM     45  CA  PHE X  45       0.900  -3.900 -16.700  1.00  1.17      7       \nATOM     46  CA  ALA X  46      -0.300  -6.100 -19.600  1.00  1.27      7       \nATOM     47  CA  GLY X  47       2.700  -6.200 -22.000  1.00  0.71      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       7.800  -4.400 -17.700  1.00  0.71      7       \nATOM     50  CA  LEU X  50       7.200  -3.200 -13.900  1.00  0.99      7       \nATOM     51  CA  GLU X  51       9.700  -1.900 -11.400  1.00  1.36      7       \nATOM     52  CA  ASP X  52      10.600  -3.100  -7.900  1.00  2.10      7       \nATOM     53  CA  GLY X  53      10.800  -0.500  -5.000  1.00  1.72      7       \nATOM     54  CA  ARG X  54      12.500   0.400  -1.700  1.00  1.65      7       \nATOM     55  CA  THR X  55      12.500  -0.200   2.200  1.00  1.62      7       \nATOM     56  CA  LEU X  56      10.500   1.300   5.100  1.00  1.57      7       \nATOM     57  CA  SER X  57      14.000   2.400   6.300  1.00  1.85      7       \nATOM     58  CA  ASP X  58      14.300   4.300   3.000  1.00  2.66      7       \nATOM     59  CA  TYR X  59      10.700   5.800   2.900  1.00  2.81      7       \nATOM     60  CA  ASN X  60      11.000   7.200   6.500  1.00  2.87      7       \nATOM     61  CA  ILE X  61       8.500   6.400   9.500  1.00  2.80      7       \nATOM     62  CA  GLN X  62       9.000   7.900  13.100  1.00  2.73      7       \nATOM     63  CA  LYS X  63       9.900   5.300  15.900  1.00  3.00      7       \nATOM     64  CA  GLU X  64      11.200   6.100  19.500  1.00  3.62      7       \nATOM     65  CA  SER X  65       7.800   6.400  21.100  1.00  3.55      7       \nATOM     66  CA  THR X  66       5.400   4.400  18.700  1.00  2.90      7       \nATOM     67  CA  LEU X  67       6.000   3.000  15.200  1.00  2.70      7       \nATOM     68  CA  HSE X  68       2.800   3.600  13.100  1.00  2.36      7       \nATOM     69  CA  LEU X  69       3.400   1.700   9.800  1.00  2.39      7       \nATOM     70  CA  VAL X  70       1.100   2.900   7.100  1.00  3.09      7       \nATOM     71  CA  LEU X  71       0.100   0.800   4.100  1.00  3.25      7       \nATOM     72  CA  ARG X  72      -3.400   0.700   2.400  1.00  3.15      7       \nATOM     73  CA  LEU X  73      -6.200  -0.700   4.300  1.00  3.48      7       \nATOM     74  CA  ARG X  74      -9.600  -2.000   3.100  1.00  3.48      7       \nATOM     75  CA  GLY X  75     -11.900  -3.800   5.700  1.00  3.62      7       \nATOM     76  CA  GLY X  76     -10.800  -5.400   8.900  1.00  3.85      7       \nEND\n",
+      "rmsxColumn": "slice_5.dcd"
+    },
+    {
+      "filename": "slice_6_first_frame.pdb",
+      "id": "slice_6",
+      "index": 6,
+      "label": "Slice 6",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1      20.300   0.200  85.400  1.00  5.90      7       \nATOM      2  CA  GLN X   2      18.600  -0.300  82.100  1.00  5.60      7       \nATOM      3  CA  ILE X   3      18.500   1.400  78.700  1.00  5.79      7       \nATOM      4  CA  PHE X   4      16.200   0.500  75.900  1.00  5.57      7       \nATOM      5  CA  VAL X   5      16.600   0.900  72.100  1.00  5.61      7       \nATOM      6  CA  LYS X   6      14.400   1.600  69.000  1.00  5.60      7       \nATOM      7  CA  THR X   7      14.200  -0.100  65.600  1.00  5.40      7       \nATOM      8  CA  LEU X   8      16.300   1.000  62.600  1.00  5.38      7       \nATOM      9  CA  THR X   9      15.100   2.200  59.100  1.00  5.31      7       \nATOM     10  CA  GLY X  10      15.000   0.200  55.700  1.00  5.38      7       \nATOM     11  CA  LYS X  11      15.500   0.900  51.900  1.00  5.69      7       \nATOM     12  CA  THR X  12      13.000   1.600  49.100  1.00  5.53      7       \nATOM     13  CA  ILE X  13      13.400   0.300  45.600  1.00  5.52      7       \nATOM     14  CA  THR X  14      13.800   1.500  42.100  1.00  5.78      7       \nATOM     15  CA  LEU X  15      10.600   1.300  39.900  1.00  5.72      7       \nATOM     16  CA  GLU X  16       9.700   2.000  36.300  1.00  5.66      7       \nATOM     17  CA  VAL X  17      12.100   1.400  33.300  1.00  5.54      7       \nATOM     18  CA  GLU X  18      12.300   2.400  29.600  1.00  5.70      7       \nATOM     19  CA  PRO X  19      10.500   0.100  27.100  1.00  5.41      7       \nATOM     20  CA  SER X  20      12.100  -2.000  24.400  1.00  5.08      7       \nATOM     21  CA  ASP X  21      13.600  -0.600  21.100  1.00  4.95      7       \nATOM     22  CA  THR X  22      14.300  -2.800  18.100  1.00  4.85      7       \nATOM     23  CA  ILE X  23      11.400  -3.700  15.800  1.00  4.54      7       \nATOM     24  CA  GLU X  24      13.000  -6.700  14.000  1.00  4.39      7       \nATOM     25  CA  ASN X  25      10.900  -9.400  15.800  1.00  3.50      7       \nATOM     26  CA  VAL X  26       7.500  -7.800  15.700  1.00  3.66      7       \nATOM     27  CA  LYS X  27       7.900  -7.000  12.000  1.00  3.30      7       \nATOM     28  CA  ALA X  28       7.900 -10.800  11.500  1.00  3.34      7       \nATOM     29  CA  LYS X  29       4.900 -11.200  14.100  1.00  2.83      7       \nATOM     30  CA  ILE X  30       2.300  -9.200  12.200  1.00  2.79      7       \nATOM     31  CA  GLN X  31       3.400 -10.100   8.800  1.00  3.32      7       \nATOM     32  CA  ASP X  32       4.400 -13.800   8.900  1.00  3.14      7       \nATOM     33  CA  LYS X  33       2.600 -15.400  11.900  1.00  2.73      7       \nATOM     34  CA  GLU X  34      -0.700 -13.300  12.100  1.00  3.13      7       \nATOM     35  CA  GLY X  35      -0.400 -13.100   8.200  1.00  3.40      7       \nATOM     36  CA  ILE X  36      -0.200 -10.200   5.700  1.00  2.66      7       \nATOM     37  CA  PRO X  37      -0.100 -11.200   1.900  1.00  2.55      7       \nATOM     38  CA  PRO X  38       1.600  -8.800  -0.600  1.00  2.36      7       \nATOM     39  CA  ASP X  39      -1.500  -8.200  -2.900  1.00  1.88      7       \nATOM     40  CA  GLN X  40      -2.200  -4.800  -1.000  1.00  2.12      7       \nATOM     41  CA  GLN X  41      -0.100  -2.000  -2.300  1.00  2.46      7       \nATOM     42  CA  ARG X  42       1.300  -2.500  -5.900  1.00  2.14      7       \nATOM     43  CA  LEU X  43      -0.700  -4.300  -8.700  1.00  1.94      7       \nATOM     44  CA  ILE X  44       0.700  -6.000 -11.700  1.00  1.75      7       \nATOM     45  CA  PHE X  45       1.500  -5.400 -15.400  1.00  1.50      7       \nATOM     46  CA  ALA X  46       0.400  -7.500 -18.300  1.00  1.68      7       \nATOM     47  CA  GLY X  47       2.500  -6.400 -21.300  1.00  0.97      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       8.100  -4.600 -17.900  1.00  1.02      7       \nATOM     50  CA  LEU X  50       8.100  -4.300 -14.100  1.00  1.66      7       \nATOM     51  CA  GLU X  51      10.500  -2.100 -12.100  1.00  1.84      7       \nATOM     52  CA  ASP X  52      12.400  -2.800  -8.900  1.00  2.04      7       \nATOM     53  CA  GLY X  53      10.500  -1.500  -5.900  1.00  1.95      7       \nATOM     54  CA  ARG X  54      10.400   0.900  -3.000  1.00  1.94      7       \nATOM     55  CA  THR X  55      12.000   0.400   0.500  1.00  2.02      7       \nATOM     56  CA  LEU X  56      11.500   0.800   4.200  1.00  2.52      7       \nATOM     57  CA  SER X  57      14.800   1.200   6.000  1.00  2.21      7       \nATOM     58  CA  ASP X  58      15.800   4.200   8.300  1.00  2.25      7       \nATOM     59  CA  TYR X  59      12.800   5.000  10.500  1.00  2.14      7       \nATOM     60  CA  ASN X  60      12.800   6.500  14.000  1.00  2.29      7       \nATOM     61  CA  ILE X  61      11.500   4.000  16.700  1.00  2.45      7       \nATOM     62  CA  GLN X  62       8.400   5.500  18.300  1.00  2.92      7       \nATOM     63  CA  LYS X  63       8.800   5.400  22.100  1.00  2.99      7       \nATOM     64  CA  GLU X  64       7.300   7.300  25.100  1.00  3.30      7       \nATOM     65  CA  SER X  65       3.400   7.000  25.200  1.00  3.51      7       \nATOM     66  CA  THR X  66       1.900   4.900  22.500  1.00  4.04      7       \nATOM     67  CA  LEU X  67       4.700   2.500  21.100  1.00  3.40      7       \nATOM     68  CA  HSE X  68       3.600   2.500  17.400  1.00  3.40      7       \nATOM     69  CA  LEU X  69       5.400   0.200  14.900  1.00  3.12      7       \nATOM     70  CA  VAL X  70       6.800   1.500  11.600  1.00  2.63      7       \nATOM     71  CA  LEU X  71       5.300  -0.900   8.900  1.00  2.49      7       \nATOM     72  CA  ARG X  72       1.500  -0.600   7.900  1.00  2.62      7       \nATOM     73  CA  LEU X  73      -1.100  -3.200   9.100  1.00  2.37      7       \nATOM     74  CA  ARG X  74      -3.300  -4.800   6.400  1.00  2.38      7       \nATOM     75  CA  GLY X  75      -6.400  -5.800   8.100  1.00  2.48      7       \nATOM     76  CA  GLY X  76      -7.500  -9.100   9.400  1.00  3.24      7       \nEND\n",
+      "rmsxColumn": "slice_6.dcd"
+    },
+    {
+      "filename": "slice_7_first_frame.pdb",
+      "id": "slice_7",
+      "index": 7,
+      "label": "Slice 7",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1      23.000   3.000 103.000  1.00  5.68      7       \nATOM      2  CA  GLN X   2      21.500   1.600  99.800  1.00  5.47      7       \nATOM      3  CA  ILE X   3      23.700   0.900  96.800  1.00  5.44      7       \nATOM      4  CA  PHE X   4      23.000   2.000  93.200  1.00  5.36      7       \nATOM      5  CA  VAL X   5      23.000   0.100  89.900  1.00  5.43      7       \nATOM      6  CA  LYS X   6      23.700   1.600  86.400  1.00  5.53      7       \nATOM      7  CA  THR X   7      21.500   1.900  83.200  1.00  5.20      7       \nATOM      8  CA  LEU X   8      21.800   0.300  79.700  1.00  5.29      7       \nATOM      9  CA  THR X   9      22.100   1.400  76.000  1.00  5.29      7       \nATOM     10  CA  GLY X  10      21.100   0.000  72.500  1.00  5.15      7       \nATOM     11  CA  LYS X  11      21.800  -0.500  68.800  1.00  5.10      7       \nATOM     12  CA  THR X  12      20.400   0.700  65.400  1.00  5.03      7       \nATOM     13  CA  ILE X  13      18.100  -1.300  63.100  1.00  5.14      7       \nATOM     14  CA  THR X  14      18.400  -3.500  59.900  1.00  5.07      7       \nATOM     15  CA  LEU X  15      19.700  -2.200  56.500  1.00  4.84      7       \nATOM     16  CA  GLU X  16      18.300  -1.500  53.000  1.00  4.91      7       \nATOM     17  CA  VAL X  17      17.900  -3.500  49.800  1.00  4.88      7       \nATOM     18  CA  GLU X  18      20.300  -3.200  46.700  1.00  5.03      7       \nATOM     19  CA  PRO X  19      19.600  -1.500  43.300  1.00  5.00      7       \nATOM     20  CA  SER X  20      18.800  -3.700  40.200  1.00  4.98      7       \nATOM     21  CA  ASP X  21      19.600  -4.200  36.400  1.00  4.89      7       \nATOM     22  CA  THR X  22      18.800  -1.700  33.700  1.00  5.20      7       \nATOM     23  CA  ILE X  23      17.100  -2.100  30.300  1.00  5.02      7       \nATOM     24  CA  GLU X  24      18.800  -3.500  27.200  1.00  4.98      7       \nATOM     25  CA  ASN X  25      17.200  -3.700  23.800  1.00  4.87      7       \nATOM     26  CA  VAL X  26      15.000  -1.500  21.400  1.00  4.88      7       \nATOM     27  CA  LYS X  27      15.100  -2.800  17.800  1.00  4.86      7       \nATOM     28  CA  ALA X  28      16.300  -6.400  17.300  1.00  4.98      7       \nATOM     29  CA  LYS X  29      12.800  -8.000  17.300  1.00  4.62      7       \nATOM     30  CA  ILE X  30      11.000  -5.800  14.800  1.00  4.42      7       \nATOM     31  CA  GLN X  31      14.100  -5.500  12.500  1.00  4.57      7       \nATOM     32  CA  ASP X  32      14.600  -9.300  12.000  1.00  3.88      7       \nATOM     33  CA  LYS X  33      11.000 -10.300  11.900  1.00  3.22      7       \nATOM     34  CA  GLU X  34       8.900  -7.200  10.800  1.00  2.36      7       \nATOM     35  CA  GLY X  35       9.400  -5.400   7.500  1.00  2.25      7       \nATOM     36  CA  ILE X  36       7.100  -3.900   4.900  1.00  2.18      7       \nATOM     37  CA  PRO X  37       7.400  -5.100   1.300  1.00  2.33      7       \nATOM     38  CA  PRO X  38       7.600  -2.800  -1.800  1.00  2.30      7       \nATOM     39  CA  ASP X  39       4.500  -4.500  -3.200  1.00  2.47      7       \nATOM     40  CA  GLN X  40       2.100  -1.500  -3.600  1.00  2.37      7       \nATOM     41  CA  GLN X  41       3.600   0.800  -6.200  1.00  2.25      7       \nATOM     42  CA  ARG X  42       4.900  -2.300  -8.000  1.00  2.23      7       \nATOM     43  CA  LEU X  43       2.000  -3.700 -10.000  1.00  2.21      7       \nATOM     44  CA  ILE X  44       2.600  -5.900 -13.200  1.00  2.24      7       \nATOM     45  CA  PHE X  45       1.000  -4.900 -16.600  1.00  2.20      7       \nATOM     46  CA  ALA X  46      -0.100  -6.700 -19.700  1.00  2.03      7       \nATOM     47  CA  GLY X  47       2.600  -5.900 -22.200  1.00  1.67      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       7.800  -5.500 -18.200  1.00  1.53      7       \nATOM     50  CA  LEU X  50       7.900  -5.300 -14.300  1.00  1.51      7       \nATOM     51  CA  GLU X  51       9.800  -2.500 -12.700  1.00  1.53      7       \nATOM     52  CA  ASP X  52      11.900  -2.800  -9.400  1.00  1.80      7       \nATOM     53  CA  GLY X  53      11.000  -2.500  -5.600  1.00  1.62      7       \nATOM     54  CA  ARG X  54      12.800   0.100  -3.300  1.00  1.92      7       \nATOM     55  CA  THR X  55      12.400   0.600   0.400  1.00  1.92      7       \nATOM     56  CA  LEU X  56      13.200   3.400   2.900  1.00  2.08      7       \nATOM     57  CA  SER X  57      15.800   3.200   5.700  1.00  2.41      7       \nATOM     58  CA  ASP X  58      15.500   3.300   9.500  1.00  2.46      7       \nATOM     59  CA  TYR X  59      15.600   6.300  11.900  1.00  2.82      7       \nATOM     60  CA  ASN X  60      18.200   6.900  14.400  1.00  2.82      7       \nATOM     61  CA  ILE X  61      17.600   5.700  18.000  1.00  2.67      7       \nATOM     62  CA  GLN X  62      18.100   7.800  21.100  1.00  2.49      7       \nATOM     63  CA  LYS X  63      19.000   6.600  24.700  1.00  2.42      7       \nATOM     64  CA  GLU X  64      18.000   9.600  26.900  1.00  2.63      7       \nATOM     65  CA  SER X  65      16.300   7.600  29.800  1.00  2.65      7       \nATOM     66  CA  THR X  66      15.800   4.100  28.200  1.00  2.62      7       \nATOM     67  CA  LEU X  67      16.100   3.500  24.400  1.00  2.33      7       \nATOM     68  CA  HSE X  68      13.500   5.100  22.000  1.00  2.60      7       \nATOM     69  CA  LEU X  69      12.700   4.200  18.300  1.00  3.02      7       \nATOM     70  CA  VAL X  70       9.600   4.500  16.100  1.00  3.07      7       \nATOM     71  CA  LEU X  71       9.000   2.000  13.300  1.00  3.61      7       \nATOM     72  CA  ARG X  72       6.000   3.100  11.200  1.00  3.39      7       \nATOM     73  CA  LEU X  73       3.800   0.000  10.200  1.00  2.91      7       \nATOM     74  CA  ARG X  74       1.200  -1.100   7.600  1.00  2.28      7       \nATOM     75  CA  GLY X  75      -0.800  -3.800   9.700  1.00  2.65      7       \nATOM     76  CA  GLY X  76      -1.900  -7.400  10.300  1.00  4.42      7       \nEND\n",
+      "rmsxColumn": "slice_7.dcd"
+    },
+    {
+      "filename": "slice_8_first_frame.pdb",
+      "id": "slice_8",
+      "index": 8,
+      "label": "Slice 8",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1      28.100   3.700 119.500  1.00  5.75      7       \nATOM      2  CA  GLN X   2      26.800   4.400 115.800  1.00  5.84      7       \nATOM      3  CA  ILE X   3      27.900   3.200 112.300  1.00  5.74      7       \nATOM      4  CA  PHE X   4      27.200   4.500 108.800  1.00  5.70      7       \nATOM      5  CA  VAL X   5      26.100   3.400 105.400  1.00  5.84      7       \nATOM      6  CA  LYS X   6      27.500   3.200 101.900  1.00  5.68      7       \nATOM      7  CA  THR X   7      25.900   4.000  98.400  1.00  5.73      7       \nATOM      8  CA  LEU X   8      25.200   2.100  95.200  1.00  5.80      7       \nATOM      9  CA  THR X   9      26.500   2.400  91.500  1.00  5.90      7       \nATOM     10  CA  GLY X  10      25.000   1.100  88.200  1.00  5.80      7       \nATOM     11  CA  LYS X  11      26.100   0.600  84.600  1.00  5.94      7       \nATOM     12  CA  THR X  12      25.600   2.300  81.100  1.00  5.90      7       \nATOM     13  CA  ILE X  13      24.700   0.000  78.000  1.00  5.88      7       \nATOM     14  CA  THR X  14      25.900  -0.200  74.300  1.00  6.13      7       \nATOM     15  CA  LEU X  15      24.800   1.300  70.900  1.00  5.95      7       \nATOM     16  CA  GLU X  16      22.400  -0.200  68.300  1.00  5.74      7       \nATOM     17  CA  VAL X  17      22.700  -1.800  64.900  1.00  5.78      7       \nATOM     18  CA  GLU X  18      21.700  -0.200  61.500  1.00  5.78      7       \nATOM     19  CA  PRO X  19      20.100  -1.100  58.100  1.00  5.84      7       \nATOM     20  CA  SER X  20      21.800  -1.300  54.600  1.00  5.75      7       \nATOM     21  CA  ASP X  21      21.000  -0.400  51.000  1.00  5.66      7       \nATOM     22  CA  THR X  22      17.800   0.400  49.000  1.00  5.43      7       \nATOM     23  CA  ILE X  23      16.800  -0.400  45.300  1.00  5.46      7       \nATOM     24  CA  GLU X  24      18.200  -3.300  43.300  1.00  5.40      7       \nATOM     25  CA  ASN X  25      17.600  -2.800  39.600  1.00  5.45      7       \nATOM     26  CA  VAL X  26      15.400  -0.600  37.400  1.00  5.84      7       \nATOM     27  CA  LYS X  27      16.600  -1.300  33.800  1.00  5.84      7       \nATOM     28  CA  ALA X  28      15.200  -4.900  33.800  1.00  4.51      7       \nATOM     29  CA  LYS X  29      13.900  -6.700  30.700  1.00  4.73      7       \nATOM     30  CA  ILE X  30      14.000  -3.800  28.000  1.00  4.09      7       \nATOM     31  CA  GLN X  31      16.300  -5.300  25.100  1.00  4.41      7       \nATOM     32  CA  ASP X  32      14.600  -8.300  23.200  1.00  4.61      7       \nATOM     33  CA  LYS X  33      12.000  -6.800  20.900  1.00  4.34      7       \nATOM     34  CA  GLU X  34      10.900  -7.300  17.300  1.00  4.45      7       \nATOM     35  CA  GLY X  35      11.900  -5.600  14.000  1.00  4.04      7       \nATOM     36  CA  ILE X  36       9.400  -4.800  11.200  1.00  3.88      7       \nATOM     37  CA  PRO X  37       8.600  -7.500   8.500  1.00  3.97      7       \nATOM     38  CA  PRO X  38       7.800  -6.300   4.800  1.00  4.07      7       \nATOM     39  CA  ASP X  39       5.300  -8.200   2.700  1.00  4.23      7       \nATOM     40  CA  GLN X  40       2.600  -6.500   0.700  1.00  4.25      7       \nATOM     41  CA  GLN X  41       4.600  -4.100  -1.600  1.00  2.86      7       \nATOM     42  CA  ARG X  42       5.400  -6.900  -4.200  1.00  3.09      7       \nATOM     43  CA  LEU X  43       3.800  -7.700  -7.700  1.00  3.20      7       \nATOM     44  CA  ILE X  44       3.900  -9.600 -11.000  1.00  2.86      7       \nATOM     45  CA  PHE X  45       4.000  -7.400 -14.300  1.00  2.19      7       \nATOM     46  CA  ALA X  46       2.600  -8.000 -17.700  1.00  2.47      7       \nATOM     47  CA  GLY X  47       4.200  -7.500 -21.200  1.00  1.71      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       7.900  -2.200 -18.400  1.00  1.29      7       \nATOM     50  CA  LEU X  50       8.500  -2.800 -14.600  1.00  1.46      7       \nATOM     51  CA  GLU X  51       8.600  -0.600 -11.400  1.00  2.03      7       \nATOM     52  CA  ASP X  52      10.600  -1.000  -8.300  1.00  2.44      7       \nATOM     53  CA  GLY X  53      10.300  -1.200  -4.500  1.00  2.70      7       \nATOM     54  CA  ARG X  54      11.600  -0.200  -1.000  1.00  2.95      7       \nATOM     55  CA  THR X  55      13.000  -1.900   2.000  1.00  3.11      7       \nATOM     56  CA  LEU X  56      12.300  -0.900   5.600  1.00  3.18      7       \nATOM     57  CA  SER X  57      14.200   0.800   8.400  1.00  3.39      7       \nATOM     58  CA  ASP X  58      14.900  -0.100  12.200  1.00  3.38      7       \nATOM     59  CA  TYR X  59      14.300   1.600  15.500  1.00  3.37      7       \nATOM     60  CA  ASN X  60      16.300   1.700  18.800  1.00  3.69      7       \nATOM     61  CA  ILE X  61      15.500   3.100  22.300  1.00  3.56      7       \nATOM     62  CA  GLN X  62      15.600   6.900  22.100  1.00  3.35      7       \nATOM     63  CA  LYS X  63      16.100   9.600  24.800  1.00  3.37      7       \nATOM     64  CA  GLU X  64      13.600  12.500  25.700  1.00  3.28      7       \nATOM     65  CA  SER X  65      13.000  11.400  29.400  1.00  3.63      7       \nATOM     66  CA  THR X  66      15.300   8.400  30.500  1.00  3.75      7       \nATOM     67  CA  LEU X  67      14.400   5.100  28.400  1.00  3.56      7       \nATOM     68  CA  HSE X  68      11.900   6.400  25.900  1.00  3.26      7       \nATOM     69  CA  LEU X  69      10.300   3.700  23.600  1.00  3.30      7       \nATOM     70  CA  VAL X  70       8.100   4.700  20.700  1.00  3.42      7       \nATOM     71  CA  LEU X  71       6.100   1.600  19.700  1.00  3.48      7       \nATOM     72  CA  ARG X  72       3.700   1.700  16.700  1.00  3.72      7       \nATOM     73  CA  LEU X  73       2.200  -1.200  14.800  1.00  4.32      7       \nATOM     74  CA  ARG X  74       3.200  -2.000  11.200  1.00  3.69      7       \nATOM     75  CA  GLY X  75      -0.400  -1.700  10.200  1.00  4.30      7       \nATOM     76  CA  GLY X  76      -3.900  -2.700  11.400  1.00  5.33      7       \nEND\n",
+      "rmsxColumn": "slice_8.dcd"
+    },
+    {
+      "filename": "slice_9_first_frame.pdb",
+      "id": "slice_9",
+      "index": 9,
+      "label": "Slice 9",
+      "pdb": "TITLE     MDANALYSIS FRAME 0: Created by PDBWriter\nCRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1           1\nATOM      1  CA  MET X   1      27.800   6.800 136.600  1.00  4.94      7       \nATOM      2  CA  GLN X   2      26.400   6.600 132.900  1.00  4.76      7       \nATOM      3  CA  ILE X   3      26.800   5.200 129.300  1.00  4.76      7       \nATOM      4  CA  PHE X   4      27.100   6.800 125.800  1.00  4.74      7       \nATOM      5  CA  VAL X   5      24.800   7.000 122.700  1.00  4.67      7       \nATOM      6  CA  LYS X   6      25.500   6.800 118.900  1.00  4.66      7       \nATOM      7  CA  THR X   7      23.900   7.800 115.600  1.00  4.67      7       \nATOM      8  CA  LEU X   8      22.800   6.400 112.200  1.00  4.44      7       \nATOM      9  CA  THR X   9      23.300   7.500 108.500  1.00  4.49      7       \nATOM     10  CA  GLY X  10      22.100   6.100 105.100  1.00  4.52      7       \nATOM     11  CA  LYS X  11      22.800   4.400 101.700  1.00  4.22      7       \nATOM     12  CA  THR X  12      24.000   5.800  98.400  1.00  4.43      7       \nATOM     13  CA  ILE X  13      22.100   5.800  95.000  1.00  4.64      7       \nATOM     14  CA  THR X  14      22.800   3.700  91.800  1.00  4.10      7       \nATOM     15  CA  LEU X  15      22.700   4.200  88.000  1.00  4.29      7       \nATOM     16  CA  GLU X  16      20.200   3.700  85.100  1.00  4.34      7       \nATOM     17  CA  VAL X  17      20.500   1.700  81.900  1.00  4.04      7       \nATOM     18  CA  GLU X  18      20.900   3.100  78.300  1.00  4.08      7       \nATOM     19  CA  PRO X  19      18.500   3.100  75.200  1.00  4.08      7       \nATOM     20  CA  SER X  20      19.200   1.000  72.100  1.00  3.73      7       \nATOM     21  CA  ASP X  21      20.100   2.000  68.500  1.00  3.82      7       \nATOM     22  CA  THR X  22      18.300   2.700  65.200  1.00  3.88      7       \nATOM     23  CA  ILE X  23      18.900   1.300  61.600  1.00  3.62      7       \nATOM     24  CA  GLU X  24      20.300   2.800  58.400  1.00  3.76      7       \nATOM     25  CA  ASN X  25      19.300   1.300  55.000  1.00  3.63      7       \nATOM     26  CA  VAL X  26      16.800   3.200  52.700  1.00  2.82      7       \nATOM     27  CA  LYS X  27      16.600   3.800  48.900  1.00  2.85      7       \nATOM     28  CA  ALA X  28      17.900   2.200  45.600  1.00  3.01      7       \nATOM     29  CA  LYS X  29      17.200   2.200  41.800  1.00  3.15      7       \nATOM     30  CA  ILE X  30      16.300   0.100  38.700  1.00  2.82      7       \nATOM     31  CA  GLN X  31      17.500  -0.100  35.000  1.00  2.75      7       \nATOM     32  CA  ASP X  32      16.700   0.700  31.400  1.00  2.69      7       \nATOM     33  CA  LYS X  33      13.700   1.400  28.900  1.00  2.50      7       \nATOM     34  CA  GLU X  34      12.600  -0.800  25.800  1.00  2.44      7       \nATOM     35  CA  GLY X  35      12.000   0.700  22.300  1.00  2.36      7       \nATOM     36  CA  ILE X  36       9.200   0.900  19.400  1.00  2.39      7       \nATOM     37  CA  PRO X  37       9.600  -1.400  16.400  1.00  2.09      7       \nATOM     38  CA  PRO X  38       9.200  -0.600  12.600  1.00  2.21      7       \nATOM     39  CA  ASP X  39       7.300  -2.100   9.800  1.00  2.10      7       \nATOM     40  CA  GLN X  40       7.200  -0.900   6.000  1.00  2.13      7       \nATOM     41  CA  GLN X  41       5.600  -2.500   2.900  1.00  1.89      7       \nATOM     42  CA  ARG X  42       7.400  -3.800  -0.200  1.00  1.74      7       \nATOM     43  CA  LEU X  43       7.200  -1.700  -3.600  1.00  1.60      7       \nATOM     44  CA  ILE X  44       5.800  -3.000  -6.800  1.00  1.42      7       \nATOM     45  CA  PHE X  45       6.700  -3.300 -10.500  1.00  1.08      7       \nATOM     46  CA  ALA X  46       4.800  -2.400 -13.800  1.00  0.95      7       \nATOM     47  CA  GLY X  47       4.400  -4.600 -16.900  1.00  0.71      7       \nATOM     48  CA  LYS X  48       5.300  -3.900 -20.600  1.00  0.00      7       \nATOM     49  CA  GLN X  49       6.800  -0.600 -19.900  1.00  1.41      7       \nATOM     50  CA  LEU X  50       8.600  -1.000 -16.500  1.00  1.66      7       \nATOM     51  CA  GLU X  51       9.500   1.900 -14.200  1.00  2.40      7       \nATOM     52  CA  ASP X  52      11.600   2.800 -11.000  1.00  2.85      7       \nATOM     53  CA  GLY X  53      10.200   2.600  -7.500  1.00  2.08      7       \nATOM     54  CA  ARG X  54      11.400   3.900  -4.200  1.00  1.93      7       \nATOM     55  CA  THR X  55      12.600   2.300  -1.000  1.00  2.01      7       \nATOM     56  CA  LEU X  56      11.900   5.100   1.500  1.00  2.46      7       \nATOM     57  CA  SER X  57      14.000   6.300   4.500  1.00  2.64      7       \nATOM     58  CA  ASP X  58      14.100   5.200   8.200  1.00  2.56      7       \nATOM     59  CA  TYR X  59      13.400   6.800  11.600  1.00  2.36      7       \nATOM     60  CA  ASN X  60      16.900   7.100  13.100  1.00  2.87      7       \nATOM     61  CA  ILE X  61      18.300   8.100  16.600  1.00  3.18      7       \nATOM     62  CA  GLN X  62      18.600  11.500  18.300  1.00  2.95      7       \nATOM     63  CA  LYS X  63      20.200  12.000  21.700  1.00  3.28      7       \nATOM     64  CA  GLU X  64      17.600  14.000  23.800  1.00  3.52      7       \nATOM     65  CA  SER X  65      18.300  12.300  27.100  1.00  4.35      7       \nATOM     66  CA  THR X  66      21.000   9.700  26.500  1.00  4.58      7       \nATOM     67  CA  LEU X  67      19.700   8.000  23.300  1.00  4.03      7       \nATOM     68  CA  HSE X  68      16.200   8.100  22.000  1.00  3.48      7       \nATOM     69  CA  LEU X  69      14.100   7.300  19.000  1.00  3.01      7       \nATOM     70  CA  VAL X  70      13.100  10.000  16.400  1.00  2.49      7       \nATOM     71  CA  LEU X  71       9.500  11.000  17.100  1.00  2.53      7       \nATOM     72  CA  ARG X  72       7.600  12.000  13.800  1.00  2.63      7       \nATOM     73  CA  LEU X  73       4.100  11.600  12.300  1.00  2.99      7       \nATOM     74  CA  ARG X  74       3.200   8.400  10.500  1.00  3.07      7       \nATOM     75  CA  GLY X  75      -0.600   8.800  10.600  1.00  3.84      7       \nATOM     76  CA  GLY X  76      -1.000  12.600  10.900  1.00  4.56      7       \nEND\n",
+      "rmsxColumn": "slice_9.dcd"
+    }
+  ],
+  "summaries": {
+    "slice_1.dcd": {
+      "max": 7.956002277201058,
+      "maxResidue": "75",
+      "mean": 3.939015845245273,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_2.dcd": {
+      "max": 9.605904465648072,
+      "maxResidue": "76",
+      "mean": 3.7308002008449335,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_3.dcd": {
+      "max": 7.095703695296351,
+      "maxResidue": "7",
+      "mean": 3.067956020960974,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_4.dcd": {
+      "max": 6.862725038836389,
+      "maxResidue": "1",
+      "mean": 3.6676098635525363,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_5.dcd": {
+      "max": 6.077676754760072,
+      "maxResidue": "2",
+      "mean": 3.5059403066717705,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_6.dcd": {
+      "max": 5.904462675788819,
+      "maxResidue": "1",
+      "mean": 3.4245644178681127,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_7.dcd": {
+      "max": 5.6815417324833835,
+      "maxResidue": "1",
+      "mean": 3.4931961544761654,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_8.dcd": {
+      "max": 6.126135362409583,
+      "maxResidue": "14",
+      "mean": 4.234067691650762,
+      "min": 0,
+      "residueCount": 76
+    },
+    "slice_9.dcd": {
+      "max": 4.944134622750798,
+      "maxResidue": "1",
+      "mean": 3.1150374429916483,
+      "min": 0,
+      "residueCount": 76
     }
   },
-  "molstarRenderStyle": {
-    "preset": "clean-interactive",
-    "outline": true
+  "title": "RMSX Flipbook Example: 1UBQ + mon_sys",
+  "visualMapping": {
+    "bfactorDomain": [
+      0,
+      1
+    ],
+    "colorDomainStep": 0.192,
+    "colorDomainUrlParams": [
+      "colorMin",
+      "colorMax"
+    ],
+    "colorTheme": "uncertainty",
+    "defaultColorMax": 9.605904465648072,
+    "defaultColorMin": 0,
+    "defaultRadiusMax": 3.18,
+    "defaultRadiusMin": 0.63,
+    "defaultThicknessScale": 1,
+    "mode": "normalize RMSX into the PDB B-factor column, then map 0..1 onto explicit Molstar putty worm radii",
+    "molstarUncertaintyReversesColorList": true,
+    "paletteOrder": "Flipbook low-to-high palette is reversed before passing to Molstar because Molstar uncertainty coloring reverses its color list internally",
+    "paletteUrlParam": "palette",
+    "radiusStep": 0.05,
+    "radiusUrlParams": [
+      "radiusMin",
+      "radiusMax"
+    ],
+    "thicknessUrlParam": "thickness"
   },
-  "flipbookReference": {
-    "defaultColumns": 3,
-    "defaultSpacingFactor": 1,
-    "minimumSpacingFactor": 0.1,
-    "maximumSpacingFactor": 2.5,
-    "tilePaddingFactor": 1.55
+  "exampleData": {
+    "topology": "1UBQ.pdb",
+    "trajectory": "mon_sys.xtc",
+    "trajectoryFrames": 316,
+    "selectedSegment": "7",
+    "requestedSlices": 9,
+    "source": {
+      "name": "TCBG Ubiquitin case study",
+      "url": "https://www.ks.uiuc.edu/Training/CaseStudies/",
+      "archive": "ubq-files.tgz",
+      "attribution": "Cruz-Chu, E. and Gumbart, J. C. Case study: Ubiquitin (2016).",
+      "redistribution": "Derived educational test fixture distributed with source attribution under the TCBG educational-use statement."
+    }
   }
 }


### PR DESCRIPTION
## Summary

- replace the synthetic three-frame poly-alanine RMSX manifest with the Galaxy-generated `1UBQ.pdb` + `mon_sys.xtc` example
- exercise all nine structural slices derived from the 316-frame trajectory across 76 ubiquitin residues
- include source, archive, attribution, and redistribution metadata in the manifest

## Context

This is the public example consumed by the `rmsxflipbook` visualization in `galaxyproject/galaxy-visualizations`. It addresses the request on galaxy-visualizations#172 for a representative public sample and screenshot rather than the sparse synthetic fixture.

The trajectory source is the TCBG Ubiquitin case study (`ubq-files.tgz`). Its copyright statement permits educational redistribution with credit but is not a standard open-data license, so I have recorded that provenance explicitly for maintainer review.

## Verification

- parsed as `flipbook-molstar-viewer/v1`
- 9 slices, 76 residues, 316 source trajectory frames
- byte-identical to the visualization package's checked-in Playwright fixture
- `rmsxflipbook` Playwright suite: 6 passed
